### PR TITLE
feat(#3): real-time trace dashboard + unreviewed highlighting

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { fetchApi } from "../lib/api";
+import { fetchApi, COLLECTOR_URL } from "../lib/api";
 import { formatDuration, formatTokens, formatTimestamp } from "../lib/format";
 
 interface Trace {
@@ -15,6 +15,7 @@ interface Trace {
   totalCost: number | null;
   tags: string | null;
   createdAt: string;
+  reviewedAt: string | null;
   issues: string[];
   hasIssues: boolean;
 }
@@ -40,6 +41,43 @@ export default function TracesPage() {
       })
       .catch(console.error)
       .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    const source = new EventSource(`${COLLECTOR_URL}/v1/traces/stream`);
+
+    const onCreated = (e: MessageEvent) => {
+      const trace = JSON.parse(e.data) as Trace;
+      setTraces((prev) => (prev.some((t) => t.id === trace.id) ? prev : [trace, ...prev]));
+      setTotal((prev) => prev + 1);
+    };
+
+    const onUpdated = (e: MessageEvent) => {
+      const trace = JSON.parse(e.data) as Trace;
+      setTraces((prev) =>
+        prev.map((t) =>
+          t.id === trace.id
+            ? {
+                ...t,
+                ...trace,
+                // Stream events carry stub issue data; keep the richer enrichment
+                // from the initial list fetch unless it becomes non-empty later.
+                issues: trace.issues.length ? trace.issues : t.issues,
+                hasIssues: trace.hasIssues || t.hasIssues,
+              }
+            : t,
+        ),
+      );
+    };
+
+    source.addEventListener("trace.created", onCreated);
+    source.addEventListener("trace.updated", onUpdated);
+
+    return () => {
+      source.removeEventListener("trace.created", onCreated);
+      source.removeEventListener("trace.updated", onUpdated);
+      source.close();
+    };
   }, []);
 
   const filtered = filter

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -119,7 +119,13 @@ export default function TracesPage() {
             let inputPreview = "";
             try {
               const parsed = JSON.parse(trace.input || "{}");
-              inputPreview = typeof parsed === "string" ? parsed : Object.values(parsed).join(" ").slice(0, 100);
+              inputPreview =
+                typeof parsed === "string"
+                  ? parsed
+                  : Object.values(parsed)
+                      .map((v) => (typeof v === "string" ? v : JSON.stringify(v)))
+                      .join(" ")
+                      .slice(0, 100);
             } catch {
               inputPreview = (trace.input || "").slice(0, 100);
             }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -124,11 +124,12 @@ export default function TracesPage() {
               inputPreview = (trace.input || "").slice(0, 100);
             }
 
+            const unreviewed = !trace.reviewedAt;
             return (
               <Link
                 key={trace.id}
                 href={`/traces/${trace.id}`}
-                className="block bg-zinc-900 border border-zinc-800 rounded-lg px-5 py-4 hover:border-zinc-700 transition-colors"
+                className={`block bg-zinc-900 border border-zinc-800 border-l-2 rounded-lg px-5 py-4 hover:border-zinc-700 transition-colors ${unreviewed ? "border-l-sky-500/40" : "border-l-zinc-800"}`}
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3 min-w-0">

--- a/apps/web/src/app/traces/[id]/page.tsx
+++ b/apps/web/src/app/traces/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { fetchApi } from "../../../lib/api";
+import { fetchApi, patchApi } from "../../../lib/api";
 import { formatDuration, formatTokens } from "../../../lib/format";
 
 interface Trace {
@@ -20,6 +20,7 @@ interface Trace {
   tags: string | null;
   createdAt: string;
   completedAt: string | null;
+  reviewedAt: string | null;
 }
 
 interface Span {
@@ -212,6 +213,12 @@ export default function TraceDetailPage() {
         setTrace(data.trace);
         setSpans(data.spans);
         setEvents(data.events);
+
+        if (data.trace && !data.trace.reviewedAt) {
+          const reviewedAt = new Date().toISOString();
+          setTrace((prev) => (prev ? { ...prev, reviewedAt } : prev));
+          patchApi(`/v1/traces/${id}`, { reviewedAt }).catch(console.error);
+        }
       })
       .catch(console.error)
       .finally(() => setLoading(false));

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,9 +1,19 @@
 "use client";
 
-const COLLECTOR_URL = process.env.NEXT_PUBLIC_COLLECTOR_URL || "http://localhost:4100";
+export const COLLECTOR_URL = process.env.NEXT_PUBLIC_COLLECTOR_URL || "http://localhost:4100";
 
 export async function fetchApi<T>(path: string): Promise<T> {
   const res = await fetch(`${COLLECTOR_URL}${path}`);
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+export async function patchApi<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${COLLECTOR_URL}${path}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json() as Promise<T>;
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pathlight",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "npm@10.9.7",
   "description": "Visual debugging, execution traces, and observability for AI agents",
   "workspaces": [
     "packages/*",

--- a/packages/collector/src/events.ts
+++ b/packages/collector/src/events.ts
@@ -1,0 +1,28 @@
+import { EventEmitter } from "node:events";
+import type { traces } from "@pathlight/db";
+
+type TraceRow = typeof traces.$inferSelect;
+
+export type TraceEventType = "trace.created" | "trace.updated";
+
+export interface TraceEvent {
+  type: TraceEventType;
+  trace: TraceRow & { issues: string[]; hasIssues: boolean };
+}
+
+class TraceEventBus extends EventEmitter {}
+
+export const traceEvents = new TraceEventBus();
+traceEvents.setMaxListeners(100);
+
+export function emitTraceEvent(type: TraceEventType, row: TraceRow) {
+  const payload: TraceEvent = {
+    type,
+    trace: {
+      ...row,
+      issues: [],
+      hasIssues: row.status === "failed" || !!row.error,
+    },
+  };
+  traceEvents.emit("trace", payload);
+}

--- a/packages/collector/src/routes/traces.ts
+++ b/packages/collector/src/routes/traces.ts
@@ -1,8 +1,10 @@
 import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import type { Db } from "@pathlight/db";
 import { traces, spans, events, scores } from "@pathlight/db";
 import { eq, desc, sql, and, gte, lte, like } from "@pathlight/db";
 import { nanoid } from "nanoid";
+import { traceEvents, emitTraceEvent, type TraceEvent } from "../events.js";
 
 export function createTraceRoutes(db: Db) {
   const app = new Hono();
@@ -71,6 +73,34 @@ export function createTraceRoutes(db: Db) {
     return c.json({ traces: enriched, total: total?.count || 0, limit, offset });
   });
 
+  // SSE stream of trace.created / trace.updated events
+  app.get("/stream", (c) => {
+    return streamSSE(c, async (stream) => {
+      const onEvent = (payload: TraceEvent) => {
+        stream.writeSSE({
+          event: payload.type,
+          data: JSON.stringify(payload.trace),
+        }).catch(() => {});
+      };
+      traceEvents.on("trace", onEvent);
+
+      const heartbeat = setInterval(() => {
+        stream.writeSSE({ event: "ping", data: "" }).catch(() => {});
+      }, 25_000);
+
+      stream.onAbort(() => {
+        clearInterval(heartbeat);
+        traceEvents.off("trace", onEvent);
+      });
+
+      while (!stream.aborted) {
+        await stream.sleep(60_000);
+      }
+      clearInterval(heartbeat);
+      traceEvents.off("trace", onEvent);
+    });
+  });
+
   // Get single trace with all spans and events
   app.get("/:id", async (c) => {
     const { id } = c.req.param();
@@ -129,6 +159,9 @@ export function createTraceRoutes(db: Db) {
       tags: body.tags ? JSON.stringify(body.tags) : null,
     }).run();
 
+    const created = await db.select().from(traces).where(eq(traces.id, id)).get();
+    if (created) emitTraceEvent("trace.created", created);
+
     return c.json({ id }, 201);
   });
 
@@ -143,6 +176,7 @@ export function createTraceRoutes(db: Db) {
       totalTokens?: number;
       totalCost?: number;
       metadata?: unknown;
+      reviewedAt?: string | null;
     }>();
 
     const updates: Record<string, unknown> = {};
@@ -153,6 +187,9 @@ export function createTraceRoutes(db: Db) {
     if (body.totalTokens !== undefined) updates.totalTokens = body.totalTokens;
     if (body.totalCost !== undefined) updates.totalCost = body.totalCost;
     if (body.metadata !== undefined) updates.metadata = JSON.stringify(body.metadata);
+    if (body.reviewedAt !== undefined) {
+      updates.reviewedAt = body.reviewedAt ? new Date(body.reviewedAt) : null;
+    }
 
     if (body.status === "completed" || body.status === "failed") {
       updates.completedAt = new Date();
@@ -163,6 +200,7 @@ export function createTraceRoutes(db: Db) {
     }
 
     const updated = await db.select().from(traces).where(eq(traces.id, id)).get();
+    if (updated) emitTraceEvent("trace.updated", updated);
     return c.json({ trace: updated });
   });
 

--- a/packages/db/drizzle/0001_adorable_layla_miller.sql
+++ b/packages/db/drizzle/0001_adorable_layla_miller.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `traces` ADD `reviewed_at` integer;

--- a/packages/db/drizzle/meta/0001_snapshot.json
+++ b/packages/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,547 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "07256b0c-f0e4-4e67-b93e-517ff48d0e29",
+  "prevId": "7ed1068e-cec3-4911-967f-6794b8f70106",
+  "tables": {
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_trace_id_traces_id_fk": {
+          "name": "events_trace_id_traces_id_fk",
+          "tableFrom": "events",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_span_id_spans_id_fk": {
+          "name": "events_span_id_spans_id_fk",
+          "tableFrom": "events",
+          "tableTo": "spans",
+          "columnsFrom": [
+            "span_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scores": {
+      "name": "scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scores_trace_id_traces_id_fk": {
+          "name": "scores_trace_id_traces_id_fk",
+          "tableFrom": "scores",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scores_span_id_spans_id_fk": {
+          "name": "scores_span_id_spans_id_fk",
+          "tableFrom": "scores",
+          "tableTo": "spans",
+          "columnsFrom": [
+            "span_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spans": {
+      "name": "spans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_span_id": {
+          "name": "parent_span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_args": {
+          "name": "tool_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_result": {
+          "name": "tool_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spans_trace_id_traces_id_fk": {
+          "name": "spans_trace_id_traces_id_fk",
+          "tableFrom": "spans",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "traces": {
+      "name": "traces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_duration_ms": {
+          "name": "total_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776287115833,
       "tag": "0000_misty_mach_iv",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1776623978289,
+      "tag": "0001_adorable_layla_miller",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -20,6 +20,7 @@ export const traces = sqliteTable("traces", {
     .notNull()
     .$defaultFn(() => new Date()),
   completedAt: integer("completed_at", { mode: "timestamp" }),
+  reviewedAt: integer("reviewed_at", { mode: "timestamp" }),
 });
 
 // A span represents a single step within a trace (LLM call, tool use, decision, etc.)


### PR DESCRIPTION
<!-- shiplog:
kind: timeline
phase: 5
closes: 3
updated_at: 2026-04-19T00:00:00Z
-->

Closes #3

## Summary

- Dashboard now updates live when new traces arrive or existing ones change status, via an SSE stream from the collector backed by an in-memory `EventEmitter`.
- Traces gain a `reviewedAt` timestamp; rows without one render with a subtle sky-tinted left border, and opening the detail page auto-stamps `reviewedAt` so the accent clears everywhere that's watching the stream.

## Timeline

- **[shiplog/plan]** Issue #3 captured the brainstorm: SSE over WebSocket (one-way traffic, zero client deps), in-memory emitter, `reviewedAt` column, auto-mark on detail open.
- **T1** Added nullable `reviewedAt` to `traces` following the existing `completedAt` pattern. Drizzle migration `0001_adorable_layla_miller.sql` adds one column.
- **T2** New `packages/collector/src/events.ts` module owns the emitter. `POST /v1/traces` and `PATCH /v1/traces/:id` emit after write. `GET /v1/traces/stream` uses Hono's `streamSSE` with a 25s heartbeat and listener cleanup on abort. PATCH now accepts `reviewedAt`.
- **T3** `apps/web/src/app/page.tsx` keeps its initial fetch and adds an `EventSource` that prepends on `trace.created` and merges on `trace.updated` — preserving existing enriched `issues` when the stream payload is a stub.
- **T4** Unreviewed rows render with `border-l-sky-500/40`; reviewed rows use a neutral border at the same width. No layout shift when the state flips.
- **T5** Detail page PATCHes `reviewedAt` on first load when null, updating state optimistically. That PATCH fires a `trace.updated` event, so any other open dashboard clears its accent in real time.

## Verification

Smoke-tested live: ran the collector, opened an SSE client, POSTed a trace, PATCHed status, PATCHed `reviewedAt`. Stream delivered `trace.created` and two `trace.updated` events with the expected payload shapes and timestamps.

```
event: trace.created
event: trace.updated  (status -> completed)
event: trace.updated  (reviewedAt set)
```

Build passes for `packages/collector` (`tsc`) and `apps/web` (`next build`).

## Open questions carried forward

- Multi-instance collector: in-memory emitter will not fan out across processes. Need a broker (Redis pub/sub) if we ever scale horizontally.
- Per-project stream filter: not yet wired. Trivial to add when the dashboard gains a project selector.
- Per-user review state: `reviewedAt` is a single global timestamp. A `trace_reviews(trace_id, user_id, ...)` table is needed if multiple humans review independently.

## Housekeeping

- Includes the pre-existing `packageManager: npm@10.9.7` pin that was sitting in the working tree.

---
Authored-by: claude-opus-4-7/1M (Claude Code)
Last-code-by: claude-opus-4-7/1M (Claude Code)
*Timeline rendered by [shiplog](https://github.com/devallibus/shiplog)*
