### PR TITLE
feat(#7): git-linked regressions + commits dashboard

### DIFF
--- a/apps/web/src/app/commits/page.tsx
+++ b/apps/web/src/app/commits/page.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { fetchApi } from "../../lib/api";
+import { formatDuration, formatTokens, formatTimestamp } from "../../lib/format";
+
+interface CommitSummary {
+  commit: string;
+  branch: string | null;
+  dirty: boolean | null;
+  traceCount: number;
+  avgDuration: number | null;
+  avgTokens: number | null;
+  avgCost: number | null;
+  failed: number;
+  firstSeen: number;
+  lastSeen: number;
+}
+
+const REGRESSION_PCT = 25; // highlight when a metric regresses by > 25%
+
+function delta(current: number | null, baseline: number | null): { pct: number; worse: boolean; better: boolean } | null {
+  if (current === null || baseline === null || baseline === 0) return null;
+  const pct = ((current - baseline) / baseline) * 100;
+  return { pct, worse: pct > REGRESSION_PCT, better: pct < -REGRESSION_PCT };
+}
+
+export default function CommitsPage() {
+  const [commits, setCommits] = useState<CommitSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchApi<{ commits: CommitSummary[] }>("/v1/traces/commits?limit=30")
+      .then((d) => setCommits(d.commits))
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // API returns newest-first (ordered by max(createdAt) desc). For regression math
+  // each row compares against the previous (older) row, which is index+1.
+  const rows = useMemo(() => {
+    return commits.map((c, i) => {
+      const baseline = commits[i + 1] || null;
+      return {
+        current: c,
+        baseline,
+        durationDelta: baseline ? delta(c.avgDuration, baseline.avgDuration) : null,
+        tokensDelta: baseline ? delta(c.avgTokens, baseline.avgTokens) : null,
+        costDelta: baseline ? delta(c.avgCost, baseline.avgCost) : null,
+      };
+    });
+  }, [commits]);
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
+      <div className="flex items-center gap-3">
+        <Link href="/" className="text-zinc-500 hover:text-zinc-300">
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+          </svg>
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold">Commits</h1>
+          <p className="text-sm text-zinc-500 mt-1">
+            Per-commit regression view — each row compares against the previous commit. A red delta means the metric got worse by more than {REGRESSION_PCT}%.
+          </p>
+        </div>
+      </div>
+
+      {loading ? (
+        <p className="text-zinc-500 py-8">Loading commits…</p>
+      ) : error ? (
+        <p className="text-red-400 text-sm py-8">{error}</p>
+      ) : rows.length === 0 ? (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-12 text-center">
+          <p className="text-zinc-400">No traces with git context yet.</p>
+          <p className="text-sm text-zinc-600 mt-1">Upgrade the SDK — it auto-captures commit/branch on every trace.</p>
+        </div>
+      ) : (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+          <div className="grid grid-cols-[140px_1fr_auto_auto_auto_auto_auto] gap-4 px-5 py-2.5 border-b border-zinc-800 text-[10px] text-zinc-600 uppercase tracking-widest">
+            <span>Commit</span>
+            <span>Branch</span>
+            <span className="text-right">Traces</span>
+            <span className="text-right">Avg duration</span>
+            <span className="text-right">Avg tokens</span>
+            <span className="text-right">Avg cost</span>
+            <span className="text-right">Last run</span>
+          </div>
+          <div className="divide-y divide-zinc-800/50">
+            {rows.map(({ current, durationDelta, tokensDelta, costDelta }) => {
+              const regression = durationDelta?.worse || tokensDelta?.worse || costDelta?.worse || current.failed > 0;
+              return (
+                <Link
+                  key={`${current.commit}-${current.branch}-${current.dirty}`}
+                  href={`/?commit=${current.commit.slice(0, 12)}`}
+                  className={`grid grid-cols-[140px_1fr_auto_auto_auto_auto_auto] gap-4 px-5 py-3 items-center text-xs hover:bg-zinc-800/30 transition-colors ${regression ? "bg-red-950/10" : ""}`}
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <code className="font-mono text-zinc-300">{current.commit.slice(0, 8)}</code>
+                    {current.dirty && (
+                      <span title="Uncommitted changes at run time" className="text-[9px] px-1 rounded bg-amber-900/30 text-amber-300 border border-amber-800/40">dirty</span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-zinc-400 truncate">{current.branch || "—"}</span>
+                    {current.failed > 0 && (
+                      <span className="text-[9px] px-1 rounded bg-red-900/40 text-red-300 border border-red-800/40">{current.failed} failed</span>
+                    )}
+                  </div>
+                  <span className="text-right text-zinc-400">{current.traceCount}</span>
+                  <MetricCell value={formatDuration(current.avgDuration)} delta={durationDelta} />
+                  <MetricCell value={formatTokens(current.avgTokens)} delta={tokensDelta} />
+                  <MetricCell value={current.avgCost ? `$${current.avgCost.toFixed(4)}` : "—"} delta={costDelta} />
+                  <span className="text-right text-zinc-500">{formatTimestamp(new Date(current.lastSeen).toISOString())}</span>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MetricCell({
+  value,
+  delta,
+}: {
+  value: string;
+  delta: { pct: number; worse: boolean; better: boolean } | null;
+}) {
+  return (
+    <div className="text-right">
+      <span className="text-zinc-300 font-mono">{value}</span>
+      {delta && Math.abs(delta.pct) >= 1 && (
+        <span className={`ml-2 text-[10px] font-mono ${delta.worse ? "text-red-400" : delta.better ? "text-emerald-400" : "text-zinc-600"}`}>
+          {delta.pct > 0 ? "+" : ""}{delta.pct.toFixed(0)}%
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { fetchApi } from "../lib/api";
+import { fetchApi, COLLECTOR_URL } from "../lib/api";
 import { formatDuration, formatTokens, formatTimestamp } from "../lib/format";
 
 interface Trace {
@@ -15,6 +15,7 @@ interface Trace {
   totalCost: number | null;
   tags: string | null;
   createdAt: string;
+  reviewedAt: string | null;
   issues: string[];
   hasIssues: boolean;
 }
@@ -40,6 +41,43 @@ export default function TracesPage() {
       })
       .catch(console.error)
       .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    const source = new EventSource(`${COLLECTOR_URL}/v1/traces/stream`);
+
+    const onCreated = (e: MessageEvent) => {
+      const trace = JSON.parse(e.data) as Trace;
+      setTraces((prev) => (prev.some((t) => t.id === trace.id) ? prev : [trace, ...prev]));
+      setTotal((prev) => prev + 1);
+    };
+
+    const onUpdated = (e: MessageEvent) => {
+      const trace = JSON.parse(e.data) as Trace;
+      setTraces((prev) =>
+        prev.map((t) =>
+          t.id === trace.id
+            ? {
+                ...t,
+                ...trace,
+                // Stream events carry stub issue data; keep the richer enrichment
+                // from the initial list fetch unless it becomes non-empty later.
+                issues: trace.issues.length ? trace.issues : t.issues,
+                hasIssues: trace.hasIssues || t.hasIssues,
+              }
+            : t,
+        ),
+      );
+    };
+
+    source.addEventListener("trace.created", onCreated);
+    source.addEventListener("trace.updated", onUpdated);
+
+    return () => {
+      source.removeEventListener("trace.created", onCreated);
+      source.removeEventListener("trace.updated", onUpdated);
+      source.close();
+    };
   }, []);
 
   const filtered = filter

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { fetchApi, COLLECTOR_URL } from "../lib/api";
 import { formatDuration, formatTokens, formatTimestamp } from "../lib/format";
 
@@ -17,6 +17,9 @@ interface Trace {
   tags: string | null;
   createdAt: string;
   reviewedAt: string | null;
+  gitCommit: string | null;
+  gitBranch: string | null;
+  gitDirty: boolean | null;
   issues: string[];
   hasIssues: boolean;
 }
@@ -29,7 +32,17 @@ const STATUS_STYLES: Record<string, { dot: string; text: string }> = {
 };
 
 export default function TracesPage() {
+  return (
+    <Suspense fallback={<div className="max-w-6xl mx-auto px-6 py-8 text-zinc-500">Loading…</div>}>
+      <TracesPageInner />
+    </Suspense>
+  );
+}
+
+function TracesPageInner() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const commitFilter = searchParams.get("commit");
   const [traces, setTraces] = useState<Trace[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -97,12 +110,14 @@ export default function TracesPage() {
     };
   }, []);
 
-  const filtered = filter
-    ? traces.filter((t) =>
-        t.name.toLowerCase().includes(filter.toLowerCase()) ||
-        t.status.includes(filter.toLowerCase())
-      )
-    : traces;
+  const filtered = traces
+    .filter((t) => (commitFilter ? (t.gitCommit || "").startsWith(commitFilter) : true))
+    .filter((t) =>
+      filter
+        ? t.name.toLowerCase().includes(filter.toLowerCase()) ||
+          t.status.includes(filter.toLowerCase())
+        : true,
+    );
 
   return (
     <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
@@ -111,15 +126,36 @@ export default function TracesPage() {
           <h1 className="text-2xl font-bold">Traces</h1>
           <p className="text-sm text-zinc-500 mt-1">{total} total trace{total !== 1 ? "s" : ""}</p>
         </div>
+        <Link
+          href="/commits"
+          className="text-xs px-3 py-1.5 rounded-md bg-zinc-900 border border-zinc-800 text-zinc-300 hover:border-zinc-700 hover:text-zinc-100 transition-colors"
+        >
+          Commits →
+        </Link>
       </div>
 
-      <input
-        type="text"
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-        placeholder="Filter by name or status..."
-        className="w-full max-w-md bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 text-sm text-zinc-300 placeholder-zinc-600 focus:outline-none focus:border-blue-500"
-      />
+      <div className="flex items-center gap-3">
+        <input
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter by name or status..."
+          className="w-full max-w-md bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 text-sm text-zinc-300 placeholder-zinc-600 focus:outline-none focus:border-blue-500"
+        />
+        {commitFilter && (
+          <div className="flex items-center gap-2 text-xs bg-zinc-900 border border-zinc-800 rounded-lg px-3 py-2">
+            <span className="text-zinc-500">commit</span>
+            <code className="font-mono text-zinc-300">{commitFilter.slice(0, 8)}</code>
+            <button
+              onClick={() => router.push("/")}
+              className="text-zinc-500 hover:text-zinc-300"
+              aria-label="Clear commit filter"
+            >
+              ×
+            </button>
+          </div>
+        )}
+      </div>
 
       {loading ? (
         <p className="text-zinc-500 py-8">Loading traces...</p>
@@ -193,6 +229,25 @@ export default function TracesPage() {
                         {tag}
                       </span>
                     ))}
+                    {trace.gitCommit && (
+                      <span
+                        title={`${trace.gitBranch || "?"} @ ${trace.gitCommit}${trace.gitDirty ? " (dirty)" : ""}`}
+                        className={`inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border font-mono ${
+                          trace.gitDirty
+                            ? "bg-amber-900/20 text-amber-300 border-amber-800/40"
+                            : "bg-zinc-800 text-zinc-400 border-zinc-700/50"
+                        }`}
+                      >
+                        <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                          <circle cx="6" cy="6" r="2" />
+                          <circle cx="18" cy="6" r="2" />
+                          <circle cx="18" cy="18" r="2" />
+                          <path strokeLinecap="round" d="M8 6h6a4 4 0 014 4v8" />
+                        </svg>
+                        {trace.gitCommit.slice(0, 7)}
+                        {trace.gitDirty && <span className="opacity-70">*</span>}
+                      </span>
+                    )}
                   </div>
                   <div className="flex items-center gap-6 shrink-0 text-xs text-zinc-500">
                     <span>{formatDuration(trace.totalDurationMs)}</span>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -119,7 +119,13 @@ export default function TracesPage() {
             let inputPreview = "";
             try {
               const parsed = JSON.parse(trace.input || "{}");
-              inputPreview = typeof parsed === "string" ? parsed : Object.values(parsed).join(" ").slice(0, 100);
+              inputPreview =
+                typeof parsed === "string"
+                  ? parsed
+                  : Object.values(parsed)
+                      .map((v) => (typeof v === "string" ? v : JSON.stringify(v)))
+                      .join(" ")
+                      .slice(0, 100);
             } catch {
               inputPreview = (trace.input || "").slice(0, 100);
             }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -124,11 +124,12 @@ export default function TracesPage() {
               inputPreview = (trace.input || "").slice(0, 100);
             }
 
+            const unreviewed = !trace.reviewedAt;
             return (
               <Link
                 key={trace.id}
                 href={`/traces/${trace.id}`}
-                className="block bg-zinc-900 border border-zinc-800 rounded-lg px-5 py-4 hover:border-zinc-700 transition-colors"
+                className={`block bg-zinc-900 border border-zinc-800 border-l-2 rounded-lg px-5 py-4 hover:border-zinc-700 transition-colors ${unreviewed ? "border-l-sky-500/40" : "border-l-zinc-800"}`}
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3 min-w-0">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { fetchApi, COLLECTOR_URL } from "../lib/api";
 import { formatDuration, formatTokens, formatTimestamp } from "../lib/format";
 
@@ -28,10 +29,26 @@ const STATUS_STYLES: Record<string, { dot: string; text: string }> = {
 };
 
 export default function TracesPage() {
+  const router = useRouter();
   const [traces, setTraces] = useState<Trace[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState("");
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const toggleSelect = (id: string) => {
+    setSelected((prev) => {
+      if (prev.includes(id)) return prev.filter((x) => x !== id);
+      if (prev.length >= 2) return [prev[1], id];
+      return [...prev, id];
+    });
+  };
+
+  const compareSelected = () => {
+    if (selected.length === 2) {
+      router.push(`/traces/compare?a=${selected[0]}&b=${selected[1]}`);
+    }
+  };
 
   useEffect(() => {
     fetchApi<{ traces: Trace[]; total: number }>("/v1/traces?limit=50")
@@ -131,14 +148,35 @@ export default function TracesPage() {
             }
 
             const unreviewed = !trace.reviewedAt;
+            const isSelected = selected.includes(trace.id);
             return (
               <Link
                 key={trace.id}
                 href={`/traces/${trace.id}`}
-                className={`block bg-zinc-900 border border-zinc-800 border-l-2 rounded-lg px-5 py-4 hover:border-zinc-700 transition-colors ${unreviewed ? "border-l-sky-500/40" : "border-l-zinc-800"}`}
+                className={`group block bg-zinc-900 border border-zinc-800 border-l-2 rounded-lg px-5 py-4 hover:border-zinc-700 transition-colors ${unreviewed ? "border-l-sky-500/40" : "border-l-zinc-800"} ${isSelected ? "ring-1 ring-blue-500/60" : ""}`}
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3 min-w-0">
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        toggleSelect(trace.id);
+                      }}
+                      aria-label={isSelected ? "Deselect for compare" : "Select for compare"}
+                      className={`w-4 h-4 rounded border shrink-0 flex items-center justify-center transition ${
+                        isSelected
+                          ? "bg-blue-500 border-blue-400 text-white"
+                          : "border-zinc-700 hover:border-zinc-500 opacity-0 group-hover:opacity-100"
+                      } ${selected.length > 0 ? "opacity-100" : ""}`}
+                    >
+                      {isSelected && (
+                        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                        </svg>
+                      )}
+                    </button>
                     <div className={`w-2 h-2 rounded-full shrink-0 ${style.dot}`} />
                     <span className="font-medium text-sm">{trace.name}</span>
                     <span className={`text-xs ${style.text}`}>{trace.status}</span>
@@ -163,11 +201,32 @@ export default function TracesPage() {
                   </div>
                 </div>
                 {inputPreview && (
-                  <p className="text-xs text-zinc-600 mt-2 truncate ml-5">{inputPreview}</p>
+                  <p className="text-xs text-zinc-600 mt-2 truncate ml-11">{inputPreview}</p>
                 )}
               </Link>
             );
           })}
+        </div>
+      )}
+
+      {selected.length > 0 && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-zinc-900 border border-zinc-700 rounded-full shadow-2xl px-4 py-2 flex items-center gap-3 z-50">
+          <span className="text-xs text-zinc-400">
+            {selected.length} selected {selected.length === 2 ? "" : "— pick one more to compare"}
+          </span>
+          <button
+            onClick={() => setSelected([])}
+            className="text-xs text-zinc-500 hover:text-zinc-300"
+          >
+            Clear
+          </button>
+          <button
+            onClick={compareSelected}
+            disabled={selected.length !== 2}
+            className="text-xs px-3 py-1.5 rounded-full bg-blue-600 hover:bg-blue-500 text-white font-medium disabled:bg-zinc-700 disabled:text-zinc-500 disabled:cursor-not-allowed transition-colors"
+          >
+            Compare →
+          </button>
         </div>
       )}
     </div>

--- a/apps/web/src/app/traces/[id]/page.tsx
+++ b/apps/web/src/app/traces/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { fetchApi } from "../../../lib/api";
+import { fetchApi, patchApi } from "../../../lib/api";
 import { formatDuration, formatTokens } from "../../../lib/format";
 
 interface Trace {
@@ -20,6 +20,7 @@ interface Trace {
   tags: string | null;
   createdAt: string;
   completedAt: string | null;
+  reviewedAt: string | null;
 }
 
 interface Span {
@@ -212,6 +213,12 @@ export default function TraceDetailPage() {
         setTrace(data.trace);
         setSpans(data.spans);
         setEvents(data.events);
+
+        if (data.trace && !data.trace.reviewedAt) {
+          const reviewedAt = new Date().toISOString();
+          setTrace((prev) => (prev ? { ...prev, reviewedAt } : prev));
+          patchApi(`/v1/traces/${id}`, { reviewedAt }).catch(console.error);
+        }
       })
       .catch(console.error)
       .finally(() => setLoading(false));

--- a/apps/web/src/app/traces/compare/page.tsx
+++ b/apps/web/src/app/traces/compare/page.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { Suspense, useEffect, useState, useMemo } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { fetchApi } from "../../../lib/api";
+import { formatDuration, formatTokens } from "../../../lib/format";
+import { diffLines, prettyJson, type DiffLine } from "../../../lib/diff";
+
+interface Trace {
+  id: string;
+  name: string;
+  status: string;
+  input: string | null;
+  output: string | null;
+  error: string | null;
+  totalDurationMs: number | null;
+  totalTokens: number | null;
+  totalCost: number | null;
+  createdAt: string;
+}
+
+interface Span {
+  id: string;
+  name: string;
+  type: string;
+  status: string;
+  input: string | null;
+  output: string | null;
+  model: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cost: number | null;
+  durationMs: number | null;
+  startedAt: string;
+}
+
+type TraceBundle = { trace: Trace; spans: Span[] };
+
+const STATUS_DOT: Record<string, string> = {
+  running: "bg-blue-500 animate-pulse",
+  completed: "bg-emerald-500",
+  failed: "bg-red-500",
+  cancelled: "bg-zinc-500",
+};
+
+function delta(a: number | null, b: number | null): { text: string; className: string } | null {
+  if (a === null || b === null || a === 0) return null;
+  const diff = b - a;
+  const pct = (diff / a) * 100;
+  const sign = diff > 0 ? "+" : "";
+  const className = Math.abs(pct) < 1 ? "text-zinc-500" : diff > 0 ? "text-amber-400" : "text-emerald-400";
+  return { text: `${sign}${pct.toFixed(0)}%`, className };
+}
+
+function alignSpans(left: Span[], right: Span[]): Array<{ a: Span | null; b: Span | null }> {
+  // Align by position in a name-keyed LCS. Spans sharing the same name at the same
+  // sequential rank are paired; unpaired spans show as adds/removes.
+  const leftNames = left.map((s) => s.name);
+  const rightNames = right.map((s) => s.name);
+  const m = leftNames.length;
+  const n = rightNames.length;
+
+  const table: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      table[i][j] = leftNames[i - 1] === rightNames[j - 1]
+        ? table[i - 1][j - 1] + 1
+        : Math.max(table[i - 1][j], table[i][j - 1]);
+    }
+  }
+
+  const pairs: Array<{ a: Span | null; b: Span | null }> = [];
+  let i = m;
+  let j = n;
+  while (i > 0 && j > 0) {
+    if (leftNames[i - 1] === rightNames[j - 1]) {
+      pairs.unshift({ a: left[i - 1], b: right[j - 1] });
+      i--;
+      j--;
+    } else if (table[i - 1][j] >= table[i][j - 1]) {
+      pairs.unshift({ a: left[i - 1], b: null });
+      i--;
+    } else {
+      pairs.unshift({ a: null, b: right[j - 1] });
+      j--;
+    }
+  }
+  while (i > 0) {
+    pairs.unshift({ a: left[i - 1], b: null });
+    i--;
+  }
+  while (j > 0) {
+    pairs.unshift({ a: null, b: right[j - 1] });
+    j--;
+  }
+  return pairs;
+}
+
+function JsonDiff({ left, right }: { left: string | null; right: string | null }) {
+  const diff = useMemo(() => diffLines(prettyJson(left), prettyJson(right)), [left, right]);
+  if (diff.length === 0 || (diff.length === 1 && diff[0].kind === "eq" && !diff[0].left)) {
+    return <p className="text-xs text-zinc-600 italic px-3 py-2">empty</p>;
+  }
+
+  const hasDiff = diff.some((d) => d.kind !== "eq");
+  if (!hasDiff) {
+    return (
+      <pre className="text-xs text-zinc-400 font-mono px-3 py-2 whitespace-pre-wrap max-h-72 overflow-y-auto">
+        {diff.map((d, i) => (d.left ?? d.right ?? "") + (i < diff.length - 1 ? "\n" : "")).join("")}
+      </pre>
+    );
+  }
+
+  return (
+    <div className="text-xs font-mono max-h-72 overflow-y-auto">
+      {diff.map((d, i) => (
+        <DiffRow key={i} line={d} />
+      ))}
+    </div>
+  );
+}
+
+function DiffRow({ line }: { line: DiffLine }) {
+  if (line.kind === "eq") {
+    return <div className="px-3 text-zinc-500 whitespace-pre-wrap">{line.left || "\u00A0"}</div>;
+  }
+  if (line.kind === "del") {
+    return <div className="px-3 bg-red-950/40 text-red-300 whitespace-pre-wrap">- {line.left || "\u00A0"}</div>;
+  }
+  return <div className="px-3 bg-emerald-950/40 text-emerald-300 whitespace-pre-wrap">+ {line.right || "\u00A0"}</div>;
+}
+
+export default function CompareTracesPage() {
+  return (
+    <Suspense fallback={<div className="max-w-7xl mx-auto px-6 py-8 text-zinc-500">Loading…</div>}>
+      <CompareTracesInner />
+    </Suspense>
+  );
+}
+
+function CompareTracesInner() {
+  const params = useSearchParams();
+  const aId = params.get("a");
+  const bId = params.get("b");
+
+  const [a, setA] = useState<TraceBundle | null>(null);
+  const [b, setB] = useState<TraceBundle | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!aId || !bId) {
+      setError("Missing trace ids (need ?a=...&b=...)");
+      setLoading(false);
+      return;
+    }
+    Promise.all([
+      fetchApi<TraceBundle>(`/v1/traces/${aId}`),
+      fetchApi<TraceBundle>(`/v1/traces/${bId}`),
+    ])
+      .then(([ra, rb]) => {
+        setA(ra);
+        setB(rb);
+      })
+      .catch((err) => setError(String(err)))
+      .finally(() => setLoading(false));
+  }, [aId, bId]);
+
+  if (loading) {
+    return <div className="max-w-7xl mx-auto px-6 py-8 text-zinc-500">Loading comparison…</div>;
+  }
+  if (error || !a || !b) {
+    return (
+      <div className="max-w-7xl mx-auto px-6 py-8">
+        <p className="text-red-400 text-sm">{error || "Failed to load traces"}</p>
+        <Link href="/" className="text-xs text-blue-400 hover:underline mt-2 inline-block">← Back to traces</Link>
+      </div>
+    );
+  }
+
+  const pairs = alignSpans(a.spans, b.spans);
+  const durationDelta = delta(a.trace.totalDurationMs, b.trace.totalDurationMs);
+  const tokenDelta = delta(a.trace.totalTokens, b.trace.totalTokens);
+  const costDelta = delta(a.trace.totalCost, b.trace.totalCost);
+
+  return (
+    <div className="max-w-7xl mx-auto px-6 py-8 space-y-6">
+      <div className="flex items-center gap-3">
+        <Link href="/" className="text-zinc-500 hover:text-zinc-300">
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+          </svg>
+        </Link>
+        <h1 className="text-xl font-bold">Compare traces</h1>
+      </div>
+
+      {/* Trace headers */}
+      <div className="grid grid-cols-2 gap-4">
+        {[a, b].map((side, idx) => (
+          <div key={side.trace.id} className="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
+            <div className="flex items-center gap-2 mb-3">
+              <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${idx === 0 ? "bg-red-900/40 text-red-300" : "bg-emerald-900/40 text-emerald-300"}`}>
+                {idx === 0 ? "A" : "B"}
+              </span>
+              <div className={`w-2 h-2 rounded-full ${STATUS_DOT[side.trace.status] || "bg-zinc-500"}`} />
+              <Link href={`/traces/${side.trace.id}`} className="font-semibold hover:underline truncate">
+                {side.trace.name}
+              </Link>
+              <span className="text-xs text-zinc-500 ml-auto font-mono">{side.trace.id.slice(0, 10)}</span>
+            </div>
+            <div className="grid grid-cols-3 gap-3 text-xs">
+              <Metric label="Duration" value={formatDuration(side.trace.totalDurationMs)} />
+              <Metric label="Tokens" value={formatTokens(side.trace.totalTokens)} />
+              <Metric label="Spans" value={String(side.spans.length)} />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Delta summary */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-lg px-5 py-3 flex items-center gap-8 text-sm">
+        <span className="text-xs text-zinc-500">B vs A:</span>
+        {durationDelta && (
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] text-zinc-600 uppercase">Duration</span>
+            <span className={`font-semibold ${durationDelta.className}`}>{durationDelta.text}</span>
+          </div>
+        )}
+        {tokenDelta && (
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] text-zinc-600 uppercase">Tokens</span>
+            <span className={`font-semibold ${tokenDelta.className}`}>{tokenDelta.text}</span>
+          </div>
+        )}
+        {costDelta && (
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] text-zinc-600 uppercase">Cost</span>
+            <span className={`font-semibold ${costDelta.className}`}>{costDelta.text}</span>
+          </div>
+        )}
+        <div className="flex items-center gap-2 ml-auto">
+          <span className="text-[10px] text-zinc-600 uppercase">Span count</span>
+          <span className="font-semibold text-zinc-300">{a.spans.length} → {b.spans.length}</span>
+        </div>
+      </div>
+
+      {/* Input / Output diff */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-zinc-400">Trace Input</h2>
+        <div className="bg-zinc-900 border border-zinc-800 rounded-lg py-2">
+          <JsonDiff left={a.trace.input} right={b.trace.input} />
+        </div>
+        <h2 className="text-sm font-semibold text-zinc-400 pt-2">Trace Output</h2>
+        <div className="bg-zinc-900 border border-zinc-800 rounded-lg py-2">
+          <JsonDiff left={a.trace.output} right={b.trace.output} />
+        </div>
+      </section>
+
+      {/* Span alignment */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-zinc-400">Aligned Spans</h2>
+        <p className="text-xs text-zinc-600">Rows paired by span name; unpaired spans show only on one side.</p>
+        <div className="bg-zinc-900 border border-zinc-800 rounded-lg divide-y divide-zinc-800/60">
+          {pairs.map((pair, i) => (
+            <SpanPairRow key={i} pair={pair} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-[10px] text-zinc-600 uppercase">{label}</p>
+      <p className="font-semibold mt-0.5">{value}</p>
+    </div>
+  );
+}
+
+function SpanPairRow({ pair }: { pair: { a: Span | null; b: Span | null } }) {
+  const [expanded, setExpanded] = useState(false);
+  const { a, b } = pair;
+  const bothPresent = a && b;
+  const durationDelta = bothPresent ? delta(a.durationMs, b.durationMs) : null;
+  const rowTint = !a ? "bg-emerald-950/20" : !b ? "bg-red-950/20" : "";
+
+  return (
+    <div className={rowTint}>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full grid grid-cols-[1fr_auto_1fr] gap-4 items-center px-4 py-2.5 hover:bg-zinc-800/30 transition-colors text-left"
+      >
+        <SpanCell span={a} side="a" />
+        <div className="text-xs text-zinc-500 font-mono w-20 text-center">
+          {durationDelta ? <span className={durationDelta.className}>{durationDelta.text}</span> : <span>→</span>}
+        </div>
+        <SpanCell span={b} side="b" />
+      </button>
+      {expanded && bothPresent && (
+        <div className="px-4 pb-3 grid grid-cols-2 gap-4">
+          <div>
+            <p className="text-[10px] text-zinc-600 uppercase tracking-widest mb-1">Input diff</p>
+            <div className="bg-zinc-950 border border-zinc-800 rounded py-1">
+              <JsonDiff left={a.input} right={b.input} />
+            </div>
+          </div>
+          <div>
+            <p className="text-[10px] text-zinc-600 uppercase tracking-widest mb-1">Output diff</p>
+            <div className="bg-zinc-950 border border-zinc-800 rounded py-1">
+              <JsonDiff left={a.output} right={b.output} />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SpanCell({ span, side }: { span: Span | null; side: "a" | "b" }) {
+  if (!span) {
+    return (
+      <div className="text-xs text-zinc-600 italic text-right">
+        {side === "a" ? "(added in B)" : "(removed in B)"}
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${STATUS_DOT[span.status] || "bg-zinc-500"}`} />
+      <span className="text-[10px] px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400 shrink-0">{span.type}</span>
+      <span className="text-xs text-zinc-200 truncate font-medium">{span.name}</span>
+      <span className="text-[10px] text-zinc-500 font-mono ml-auto shrink-0">{formatDuration(span.durationMs)}</span>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,9 +1,19 @@
 "use client";
 
-const COLLECTOR_URL = process.env.NEXT_PUBLIC_COLLECTOR_URL || "http://localhost:4100";
+export const COLLECTOR_URL = process.env.NEXT_PUBLIC_COLLECTOR_URL || "http://localhost:4100";
 
 export async function fetchApi<T>(path: string): Promise<T> {
   const res = await fetch(`${COLLECTOR_URL}${path}`);
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+export async function patchApi<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${COLLECTOR_URL}${path}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json() as Promise<T>;
 }

--- a/apps/web/src/lib/diff.ts
+++ b/apps/web/src/lib/diff.ts
@@ -1,0 +1,58 @@
+export type DiffLine = {
+  kind: "eq" | "add" | "del";
+  left?: string;
+  right?: string;
+};
+
+function lcsTable(a: string[], b: string[]): number[][] {
+  const m = a.length;
+  const n = b.length;
+  const table: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      table[i][j] = a[i - 1] === b[j - 1] ? table[i - 1][j - 1] + 1 : Math.max(table[i - 1][j], table[i][j - 1]);
+    }
+  }
+  return table;
+}
+
+export function diffLines(leftText: string, rightText: string): DiffLine[] {
+  const a = leftText.split("\n");
+  const b = rightText.split("\n");
+  const table = lcsTable(a, b);
+
+  const result: DiffLine[] = [];
+  let i = a.length;
+  let j = b.length;
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      result.unshift({ kind: "eq", left: a[i - 1], right: b[j - 1] });
+      i--;
+      j--;
+    } else if (table[i - 1][j] >= table[i][j - 1]) {
+      result.unshift({ kind: "del", left: a[i - 1] });
+      i--;
+    } else {
+      result.unshift({ kind: "add", right: b[j - 1] });
+      j--;
+    }
+  }
+  while (i > 0) {
+    result.unshift({ kind: "del", left: a[i - 1] });
+    i--;
+  }
+  while (j > 0) {
+    result.unshift({ kind: "add", right: b[j - 1] });
+    j--;
+  }
+  return result;
+}
+
+export function prettyJson(str: string | null | undefined): string {
+  if (!str) return "";
+  try {
+    return JSON.stringify(JSON.parse(str), null, 2);
+  } catch {
+    return str;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pathlight",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "npm@10.9.7",
   "description": "Visual debugging, execution traces, and observability for AI agents",
   "workspaces": [
     "packages/*",

--- a/packages/collector/src/events.ts
+++ b/packages/collector/src/events.ts
@@ -1,0 +1,28 @@
+import { EventEmitter } from "node:events";
+import type { traces } from "@pathlight/db";
+
+type TraceRow = typeof traces.$inferSelect;
+
+export type TraceEventType = "trace.created" | "trace.updated";
+
+export interface TraceEvent {
+  type: TraceEventType;
+  trace: TraceRow & { issues: string[]; hasIssues: boolean };
+}
+
+class TraceEventBus extends EventEmitter {}
+
+export const traceEvents = new TraceEventBus();
+traceEvents.setMaxListeners(100);
+
+export function emitTraceEvent(type: TraceEventType, row: TraceRow) {
+  const payload: TraceEvent = {
+    type,
+    trace: {
+      ...row,
+      issues: [],
+      hasIssues: row.status === "failed" || !!row.error,
+    },
+  };
+  traceEvents.emit("trace", payload);
+}

--- a/packages/collector/src/routes/traces.ts
+++ b/packages/collector/src/routes/traces.ts
@@ -73,6 +73,39 @@ export function createTraceRoutes(db: Db) {
     return c.json({ traces: enriched, total: total?.count || 0, limit, offset });
   });
 
+  // Per-commit aggregate stats. Powers the regressions dashboard.
+  app.get("/commits", async (c) => {
+    const projectId = c.req.query("projectId");
+    const name = c.req.query("name");
+    const limit = Math.min(parseInt(c.req.query("limit") || "20"), 100);
+
+    const conditions = [sql`${traces.gitCommit} IS NOT NULL`];
+    if (projectId) conditions.push(eq(traces.projectId, projectId));
+    if (name) conditions.push(eq(traces.name, name));
+
+    const rows = await db
+      .select({
+        commit: traces.gitCommit,
+        branch: traces.gitBranch,
+        dirty: traces.gitDirty,
+        traceCount: sql<number>`count(*)`.as("trace_count"),
+        avgDuration: sql<number>`avg(${traces.totalDurationMs})`.as("avg_duration"),
+        avgTokens: sql<number>`avg(${traces.totalTokens})`.as("avg_tokens"),
+        avgCost: sql<number>`avg(${traces.totalCost})`.as("avg_cost"),
+        failed: sql<number>`sum(case when ${traces.status} = 'failed' then 1 else 0 end)`.as("failed"),
+        firstSeen: sql<number>`min(${traces.createdAt})`.as("first_seen"),
+        lastSeen: sql<number>`max(${traces.createdAt})`.as("last_seen"),
+      })
+      .from(traces)
+      .where(and(...conditions))
+      .groupBy(traces.gitCommit, traces.gitBranch, traces.gitDirty)
+      .orderBy(desc(sql`max(${traces.createdAt})`))
+      .limit(limit)
+      .all();
+
+    return c.json({ commits: rows });
+  });
+
   // SSE stream of trace.created / trace.updated events
   app.get("/stream", (c) => {
     return streamSSE(c, async (stream) => {
@@ -142,6 +175,9 @@ export function createTraceRoutes(db: Db) {
       input?: unknown;
       metadata?: unknown;
       tags?: string[];
+      gitCommit?: string;
+      gitBranch?: string;
+      gitDirty?: boolean;
     }>();
 
     if (!body.name) {
@@ -157,6 +193,9 @@ export function createTraceRoutes(db: Db) {
       input: body.input ? JSON.stringify(body.input) : null,
       metadata: body.metadata ? JSON.stringify(body.metadata) : null,
       tags: body.tags ? JSON.stringify(body.tags) : null,
+      gitCommit: body.gitCommit || null,
+      gitBranch: body.gitBranch || null,
+      gitDirty: body.gitDirty ?? null,
     }).run();
 
     const created = await db.select().from(traces).where(eq(traces.id, id)).get();

--- a/packages/collector/src/routes/traces.ts
+++ b/packages/collector/src/routes/traces.ts
@@ -1,8 +1,10 @@
 import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import type { Db } from "@pathlight/db";
 import { traces, spans, events, scores } from "@pathlight/db";
 import { eq, desc, sql, and, gte, lte, like } from "@pathlight/db";
 import { nanoid } from "nanoid";
+import { traceEvents, emitTraceEvent, type TraceEvent } from "../events.js";
 
 export function createTraceRoutes(db: Db) {
   const app = new Hono();
@@ -71,6 +73,34 @@ export function createTraceRoutes(db: Db) {
     return c.json({ traces: enriched, total: total?.count || 0, limit, offset });
   });
 
+  // SSE stream of trace.created / trace.updated events
+  app.get("/stream", (c) => {
+    return streamSSE(c, async (stream) => {
+      const onEvent = (payload: TraceEvent) => {
+        stream.writeSSE({
+          event: payload.type,
+          data: JSON.stringify(payload.trace),
+        }).catch(() => {});
+      };
+      traceEvents.on("trace", onEvent);
+
+      const heartbeat = setInterval(() => {
+        stream.writeSSE({ event: "ping", data: "" }).catch(() => {});
+      }, 25_000);
+
+      stream.onAbort(() => {
+        clearInterval(heartbeat);
+        traceEvents.off("trace", onEvent);
+      });
+
+      while (!stream.aborted) {
+        await stream.sleep(60_000);
+      }
+      clearInterval(heartbeat);
+      traceEvents.off("trace", onEvent);
+    });
+  });
+
   // Get single trace with all spans and events
   app.get("/:id", async (c) => {
     const { id } = c.req.param();
@@ -129,6 +159,9 @@ export function createTraceRoutes(db: Db) {
       tags: body.tags ? JSON.stringify(body.tags) : null,
     }).run();
 
+    const created = await db.select().from(traces).where(eq(traces.id, id)).get();
+    if (created) emitTraceEvent("trace.created", created);
+
     return c.json({ id }, 201);
   });
 
@@ -143,6 +176,7 @@ export function createTraceRoutes(db: Db) {
       totalTokens?: number;
       totalCost?: number;
       metadata?: unknown;
+      reviewedAt?: string | null;
     }>();
 
     const updates: Record<string, unknown> = {};
@@ -153,6 +187,9 @@ export function createTraceRoutes(db: Db) {
     if (body.totalTokens !== undefined) updates.totalTokens = body.totalTokens;
     if (body.totalCost !== undefined) updates.totalCost = body.totalCost;
     if (body.metadata !== undefined) updates.metadata = JSON.stringify(body.metadata);
+    if (body.reviewedAt !== undefined) {
+      updates.reviewedAt = body.reviewedAt ? new Date(body.reviewedAt) : null;
+    }
 
     if (body.status === "completed" || body.status === "failed") {
       updates.completedAt = new Date();
@@ -163,6 +200,7 @@ export function createTraceRoutes(db: Db) {
     }
 
     const updated = await db.select().from(traces).where(eq(traces.id, id)).get();
+    if (updated) emitTraceEvent("trace.updated", updated);
     return c.json({ trace: updated });
   });
 

--- a/packages/db/drizzle/0001_adorable_layla_miller.sql
+++ b/packages/db/drizzle/0001_adorable_layla_miller.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `traces` ADD `reviewed_at` integer;

--- a/packages/db/drizzle/0002_silent_manta.sql
+++ b/packages/db/drizzle/0002_silent_manta.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `traces` ADD `git_commit` text;--> statement-breakpoint
+ALTER TABLE `traces` ADD `git_branch` text;--> statement-breakpoint
+ALTER TABLE `traces` ADD `git_dirty` integer;

--- a/packages/db/drizzle/meta/0001_snapshot.json
+++ b/packages/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,547 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "07256b0c-f0e4-4e67-b93e-517ff48d0e29",
+  "prevId": "7ed1068e-cec3-4911-967f-6794b8f70106",
+  "tables": {
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_trace_id_traces_id_fk": {
+          "name": "events_trace_id_traces_id_fk",
+          "tableFrom": "events",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_span_id_spans_id_fk": {
+          "name": "events_span_id_spans_id_fk",
+          "tableFrom": "events",
+          "tableTo": "spans",
+          "columnsFrom": [
+            "span_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scores": {
+      "name": "scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scores_trace_id_traces_id_fk": {
+          "name": "scores_trace_id_traces_id_fk",
+          "tableFrom": "scores",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scores_span_id_spans_id_fk": {
+          "name": "scores_span_id_spans_id_fk",
+          "tableFrom": "scores",
+          "tableTo": "spans",
+          "columnsFrom": [
+            "span_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spans": {
+      "name": "spans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_span_id": {
+          "name": "parent_span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_args": {
+          "name": "tool_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_result": {
+          "name": "tool_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spans_trace_id_traces_id_fk": {
+          "name": "spans_trace_id_traces_id_fk",
+          "tableFrom": "spans",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "traces": {
+      "name": "traces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_duration_ms": {
+          "name": "total_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,568 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5eaf2fd0-d094-41a5-8d99-5b3c8c4051ce",
+  "prevId": "07256b0c-f0e4-4e67-b93e-517ff48d0e29",
+  "tables": {
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_trace_id_traces_id_fk": {
+          "name": "events_trace_id_traces_id_fk",
+          "tableFrom": "events",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_span_id_spans_id_fk": {
+          "name": "events_span_id_spans_id_fk",
+          "tableFrom": "events",
+          "tableTo": "spans",
+          "columnsFrom": [
+            "span_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scores": {
+      "name": "scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scores_trace_id_traces_id_fk": {
+          "name": "scores_trace_id_traces_id_fk",
+          "tableFrom": "scores",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scores_span_id_spans_id_fk": {
+          "name": "scores_span_id_spans_id_fk",
+          "tableFrom": "scores",
+          "tableTo": "spans",
+          "columnsFrom": [
+            "span_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spans": {
+      "name": "spans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_span_id": {
+          "name": "parent_span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_args": {
+          "name": "tool_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_result": {
+          "name": "tool_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spans_trace_id_traces_id_fk": {
+          "name": "spans_trace_id_traces_id_fk",
+          "tableFrom": "spans",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "traces": {
+      "name": "traces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_duration_ms": {
+          "name": "total_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_commit": {
+          "name": "git_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_dirty": {
+          "name": "git_dirty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776287115833,
       "tag": "0000_misty_mach_iv",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1776623978289,
+      "tag": "0001_adorable_layla_miller",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776623978289,
       "tag": "0001_adorable_layla_miller",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1776638142334,
+      "tag": "0002_silent_manta",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -21,6 +21,11 @@ export const traces = sqliteTable("traces", {
     .$defaultFn(() => new Date()),
   completedAt: integer("completed_at", { mode: "timestamp" }),
   reviewedAt: integer("reviewed_at", { mode: "timestamp" }),
+  // Git provenance — captured by the SDK at trace start so dashboard can
+  // attribute latency/cost regressions back to a specific commit.
+  gitCommit: text("git_commit"),          // full SHA, e.g. 7a2bf14...
+  gitBranch: text("git_branch"),          // e.g. "feature/retry-loop"
+  gitDirty: integer("git_dirty", { mode: "boolean" }),  // uncommitted changes at run time
 });
 
 // A span represents a single step within a trace (LLM call, tool use, decision, etc.)

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -20,6 +20,7 @@ export const traces = sqliteTable("traces", {
     .notNull()
     .$defaultFn(() => new Date()),
   completedAt: integer("completed_at", { mode: "timestamp" }),
+  reviewedAt: integer("reviewed_at", { mode: "timestamp" }),
 });
 
 // A span represents a single step within a trace (LLM call, tool use, decision, etc.)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -15,6 +15,31 @@
  *   trace.end({ output: finalResult });
  */
 
+import { execSync } from "node:child_process";
+
+interface GitContext {
+  commit: string;
+  branch: string;
+  dirty: boolean;
+}
+
+let cachedGit: GitContext | null | undefined;
+
+// Capture git HEAD / branch / dirtiness once per process. Returns null when the
+// process isn't inside a git checkout or when git isn't on PATH.
+function detectGitContext(): GitContext | null {
+  if (cachedGit !== undefined) return cachedGit;
+  try {
+    const commit = execSync("git rev-parse HEAD", { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+    const status = execSync("git status --porcelain", { stdio: ["ignore", "pipe", "ignore"] }).toString();
+    cachedGit = { commit, branch, dirty: status.length > 0 };
+  } catch {
+    cachedGit = null;
+  }
+  return cachedGit;
+}
+
 // Capture the caller's source location from the stack trace
 function captureSource(): { file: string; line: number; column: number; func: string } | null {
   const err = new Error();
@@ -46,17 +71,21 @@ interface PathlightConfig {
   baseUrl: string;
   projectId?: string;
   apiKey?: string;
+  /** Disable automatic git-context capture (commit/branch/dirty). */
+  disableGitContext?: boolean;
 }
 
 export class Pathlight {
   private baseUrl: string;
   private projectId?: string;
   private apiKey?: string;
+  private gitContextDisabled: boolean;
 
   constructor(config: PathlightConfig) {
     this.baseUrl = config.baseUrl.replace(/\/$/, "");
     this.projectId = config.projectId;
     this.apiKey = config.apiKey;
+    this.gitContextDisabled = !!config.disableGitContext;
   }
 
   private async post(path: string, body: unknown) {
@@ -89,7 +118,14 @@ export class Pathlight {
 
   /** @internal */
   async _createTrace(data: { name: string; projectId?: string; input?: unknown; tags?: string[]; metadata?: unknown }) {
-    return this.post("/v1/traces", { ...data, projectId: data.projectId || this.projectId });
+    const git = this.gitContextDisabled ? null : detectGitContext();
+    return this.post("/v1/traces", {
+      ...data,
+      projectId: data.projectId || this.projectId,
+      ...(git
+        ? { gitCommit: git.commit, gitBranch: git.branch, gitDirty: git.dirty }
+        : {}),
+    });
   }
 
   /** @internal */


### PR DESCRIPTION
## Summary
- DB columns + migration: \`git_commit\`, \`git_branch\`, \`git_dirty\` on traces
- SDK auto-captures git HEAD/branch/dirty once per process (opt-out via \`disableGitContext\`)
- Collector: POST /v1/traces accepts git fields; new GET /v1/traces/commits aggregate
- Dashboard: commit badge on every trace row, \`?commit=\` filter, new /commits regression view (flags >25% worse-than-previous metrics in red)

## Why
Closes #7. The top-requested companion to trace diff (#5): when a commit spikes cost or latency, you now see it immediately and can click through to the specific runs to diff them.

## Depends on
Stacked on #6 (trace diff). Merge #6 first, or merge both and rebase.

## Test plan
- [ ] Run the db migration (\`npm run db:migrate -w packages/db\`)
- [ ] Start collector + web via \`npx turbo dev\`
- [ ] Emit a trace from inside a git repo — commit badge should appear on the list row
- [ ] Visit /commits — verify aggregate rows, delta percentages, regression highlighting
- [ ] Click a commit row → lands on /?commit=... filter
- [ ] Set \`disableGitContext: true\` in SDK config → new traces omit git fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)