### PR TITLE
feat(#9): @pathlight/eval — assertion DSL + CI runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -484,6 +484,10 @@
       "resolved": "packages/db",
       "link": true
     },
+    "node_modules/@pathlight/eval": {
+      "resolved": "packages/eval",
+      "link": true
+    },
     "node_modules/@pathlight/sdk": {
       "resolved": "packages/sdk",
       "link": true
@@ -2207,6 +2211,17 @@
       "devDependencies": {
         "drizzle-kit": "^0.31.0",
         "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "packages/eval": {
+      "name": "@pathlight/eval",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "pathlight-eval": "bin/pathlight-eval.js"
+      },
+      "devDependencies": {
         "typescript": "^5.7.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pathlight",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "npm@10.9.7",
   "description": "Visual debugging, execution traces, and observability for AI agents",
   "workspaces": [
     "packages/*",

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -1,0 +1,64 @@
+# @pathlight/eval
+
+Assertion DSL and CI runner for [Pathlight](https://github.com/syndicalt/pathlight) traces.
+
+Write pytest-style assertions against your agent's recent runs. Gate merges on
+regressions, catch tool loops before they ship, keep per-run cost under control.
+
+## Install
+
+```bash
+npm install --save-dev @pathlight/eval
+```
+
+## Write a spec
+
+```js
+// specs/estimate.mjs
+import { expect, evaluate } from "@pathlight/eval";
+
+export default () => evaluate(
+  { baseUrl: "http://localhost:4100", name: "estimate", limit: 20 },
+  (t) => {
+    expect(t).toSucceed();
+    expect(t).toCompleteWithin("10s");
+    expect(t).toCostLessThan(0.05);
+    expect(t).toHaveNoToolLoops();
+    expect(t).toCallTool("search_docs").atMost(3);
+  },
+);
+```
+
+## Run it
+
+```bash
+npx pathlight-eval specs/estimate.mjs
+```
+
+Exits `0` if every trace passes; `1` (with a per-trace failure list) otherwise,
+so it drops into CI without fuss.
+
+## Assertions
+
+| Matcher                      | Fails when                                                  |
+| ---------------------------- | ----------------------------------------------------------- |
+| `toSucceed()`                | trace status !== `completed`                                |
+| `toFail()`                   | trace status !== `failed`                                   |
+| `toCompleteWithin(d)`        | total duration > `d` (ms number or `"5s"` / `"2m"` string)  |
+| `toCostLessThan(usd)`        | total cost >= `usd`                                         |
+| `toUseAtMostTokens(n)`       | total tokens > `n`                                          |
+| `toHaveNoFailedSpans()`      | any span status === `failed`                                |
+| `toHaveNoToolLoops(n=3)`     | same tool called `n` or more times consecutively            |
+| `toCallTool(name).atMost(n)` | tool called > `n` times                                     |
+| `toCallTool(name).atLeast(n)`| tool called < `n` times                                     |
+| `toCallTool(name).exactly(n)`| tool called != `n` times                                    |
+| `toMatchOutput(re \| str)`   | trace output doesn't match                                  |
+
+## In CI
+
+```yaml
+- run: npx pathlight-eval specs/estimate.mjs --base-url ${{ secrets.PATHLIGHT_URL }}
+```
+
+Any failure fails the job. Combine with git-linked traces (SDK auto-captures
+commit SHA) to answer "did this PR regress any agent?"

--- a/packages/eval/bin/pathlight-eval.js
+++ b/packages/eval/bin/pathlight-eval.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// @pathlight/eval CLI — loads a spec file and runs it against recent traces.
+//
+// Usage:
+//   pathlight-eval <spec-file> [--base-url http://localhost:4100]
+//
+// The spec file is a plain ES module (.js or .mjs) that exports default a
+// function, or that calls evaluate(...) directly. Examples:
+//
+//   // spec-default-export.mjs
+//   import { expect, evaluate } from "@pathlight/eval";
+//   export default () => evaluate(
+//     { baseUrl: "http://localhost:4100", name: "estimate", limit: 20 },
+//     (t) => {
+//       expect(t).toSucceed();
+//       expect(t).toCompleteWithin("10s");
+//     }
+//   );
+
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+
+const args = process.argv.slice(2);
+if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+  console.log("Usage: pathlight-eval <spec-file> [--base-url <url>]");
+  process.exit(args.length === 0 ? 1 : 0);
+}
+
+const specPath = args[0];
+const baseUrlIdx = args.indexOf("--base-url");
+const baseUrl = baseUrlIdx >= 0 ? args[baseUrlIdx + 1] : process.env.PATHLIGHT_URL || "http://localhost:4100";
+
+process.env.PATHLIGHT_URL = baseUrl;
+
+const abs = resolve(process.cwd(), specPath);
+let mod;
+try {
+  mod = await import(pathToFileURL(abs).href);
+} catch (err) {
+  console.error(`Failed to load spec file ${abs}:`);
+  console.error(err);
+  process.exit(2);
+}
+
+const runner = typeof mod.default === "function" ? mod.default : null;
+if (!runner) {
+  console.error("Spec file must export default a function returning an EvalResult.");
+  process.exit(2);
+}
+
+const start = Date.now();
+let result;
+try {
+  result = await runner();
+} catch (err) {
+  console.error("Spec file threw before returning a result:");
+  console.error(err);
+  process.exit(2);
+}
+
+if (!result || typeof result.passed !== "number") {
+  console.error("Spec did not return an EvalResult (did you return the evaluate() promise?)");
+  process.exit(2);
+}
+
+const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+
+console.log("");
+console.log(`Pathlight eval — ${result.total} trace${result.total === 1 ? "" : "s"} checked in ${elapsed}s`);
+console.log(`  Passed: ${result.passed}`);
+console.log(`  Failed: ${result.failed}`);
+
+if (result.failures.length > 0) {
+  console.log("");
+  console.log("Failures:");
+  for (const f of result.failures) {
+    console.log(`  - [${f.traceId.slice(0, 10)}] ${f.rule}: ${f.message}`);
+  }
+  process.exit(1);
+}
+
+process.exit(0);

--- a/packages/eval/examples/estimate-spec.mjs
+++ b/packages/eval/examples/estimate-spec.mjs
@@ -1,0 +1,24 @@
+// Example spec: assert the "estimate" agent meets quality/cost targets.
+//
+//   pathlight-eval packages/eval/examples/estimate-spec.mjs --base-url http://localhost:4100
+//
+// Add this to a GitHub Action to gate merges on agent regressions.
+
+import { expect, evaluate } from "@pathlight/eval";
+
+export default () =>
+  evaluate(
+    {
+      baseUrl: process.env.PATHLIGHT_URL || "http://localhost:4100",
+      name: "estimate",
+      limit: 20,
+    },
+    (t) => {
+      expect(t).toSucceed();
+      expect(t).toCompleteWithin("20s");
+      expect(t).toCostLessThan(0.05);
+      expect(t).toUseAtMostTokens(4000);
+      expect(t).toHaveNoFailedSpans();
+      expect(t).toHaveNoToolLoops();
+    },
+  );

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@pathlight/eval",
+  "version": "0.1.0",
+  "description": "Assertion DSL and CI runner for Pathlight traces",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "bin": {
+    "pathlight-eval": "./bin/pathlight-eval.js"
+  },
+  "files": [
+    "dist",
+    "bin",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": ["ai", "agent", "eval", "assert", "testing", "ci"],
+  "author": "Nicholas Blanchard",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/syndicalt/pathlight.git",
+    "directory": "packages/eval"
+  },
+  "homepage": "https://github.com/syndicalt/pathlight",
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -1,0 +1,295 @@
+/**
+ * @pathlight/eval — pytest-style assertions over Pathlight traces.
+ *
+ * Usage:
+ *   import { expect, evaluate } from "@pathlight/eval";
+ *
+ *   await evaluate({
+ *     baseUrl: "http://localhost:4100",
+ *     name: "estimate",
+ *     limit: 20,
+ *   }, (trace) => {
+ *     expect(trace).toSucceed();
+ *     expect(trace).toCompleteWithin("5s");
+ *     expect(trace).toCostLessThan(0.10);
+ *     expect(trace).toCallTool("database").atMost(3);
+ *   });
+ */
+
+export interface TraceRecord {
+  id: string;
+  name: string;
+  status: "running" | "completed" | "failed" | "cancelled";
+  input: string | null;
+  output: string | null;
+  error: string | null;
+  totalDurationMs: number | null;
+  totalTokens: number | null;
+  totalCost: number | null;
+  createdAt: string;
+  gitCommit?: string | null;
+  gitBranch?: string | null;
+}
+
+export interface SpanRecord {
+  id: string;
+  name: string;
+  type: "llm" | "tool" | "retrieval" | "agent" | "chain" | "custom";
+  status: "running" | "completed" | "failed";
+  toolName: string | null;
+  durationMs: number | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cost: number | null;
+  error: string | null;
+}
+
+export interface TraceBundle {
+  trace: TraceRecord;
+  spans: SpanRecord[];
+}
+
+export class AssertionError extends Error {
+  constructor(
+    message: string,
+    public readonly traceId: string,
+    public readonly rule: string,
+  ) {
+    super(message);
+    this.name = "AssertionError";
+  }
+}
+
+function parseDuration(input: number | string): number {
+  if (typeof input === "number") return input;
+  const m = input.trim().match(/^(\d+(?:\.\d+)?)(ms|s|m)?$/);
+  if (!m) throw new Error(`Invalid duration: ${input}`);
+  const n = parseFloat(m[1]);
+  const unit = m[2] || "ms";
+  return unit === "s" ? n * 1000 : unit === "m" ? n * 60_000 : n;
+}
+
+class ToolAssertion {
+  constructor(
+    private readonly bundle: TraceBundle,
+    private readonly toolName: string,
+  ) {}
+
+  private count(): number {
+    return this.bundle.spans.filter((s) => s.type === "tool" && s.toolName === this.toolName).length;
+  }
+
+  atMost(max: number): void {
+    const c = this.count();
+    if (c > max) {
+      throw new AssertionError(
+        `Tool ${this.toolName} called ${c} times (expected ≤ ${max})`,
+        this.bundle.trace.id,
+        `toCallTool(${this.toolName}).atMost(${max})`,
+      );
+    }
+  }
+
+  atLeast(min: number): void {
+    const c = this.count();
+    if (c < min) {
+      throw new AssertionError(
+        `Tool ${this.toolName} called ${c} times (expected ≥ ${min})`,
+        this.bundle.trace.id,
+        `toCallTool(${this.toolName}).atLeast(${min})`,
+      );
+    }
+  }
+
+  exactly(n: number): void {
+    const c = this.count();
+    if (c !== n) {
+      throw new AssertionError(
+        `Tool ${this.toolName} called ${c} times (expected ${n})`,
+        this.bundle.trace.id,
+        `toCallTool(${this.toolName}).exactly(${n})`,
+      );
+    }
+  }
+}
+
+export class TraceAssertion {
+  constructor(private readonly bundle: TraceBundle) {}
+
+  toSucceed(): void {
+    const s = this.bundle.trace.status;
+    if (s !== "completed") {
+      throw new AssertionError(
+        `Trace status is '${s}' (expected 'completed')`,
+        this.bundle.trace.id,
+        "toSucceed()",
+      );
+    }
+  }
+
+  toFail(): void {
+    if (this.bundle.trace.status !== "failed") {
+      throw new AssertionError(
+        `Trace status is '${this.bundle.trace.status}' (expected 'failed')`,
+        this.bundle.trace.id,
+        "toFail()",
+      );
+    }
+  }
+
+  toCompleteWithin(duration: number | string): void {
+    const max = parseDuration(duration);
+    const actual = this.bundle.trace.totalDurationMs;
+    if (actual === null || actual > max) {
+      throw new AssertionError(
+        `Trace took ${actual ?? "?"}ms (expected ≤ ${max}ms)`,
+        this.bundle.trace.id,
+        `toCompleteWithin(${duration})`,
+      );
+    }
+  }
+
+  toCostLessThan(usd: number): void {
+    const cost = this.bundle.trace.totalCost ?? 0;
+    if (cost >= usd) {
+      throw new AssertionError(
+        `Trace cost $${cost.toFixed(4)} (expected < $${usd.toFixed(4)})`,
+        this.bundle.trace.id,
+        `toCostLessThan(${usd})`,
+      );
+    }
+  }
+
+  toUseAtMostTokens(max: number): void {
+    const t = this.bundle.trace.totalTokens ?? 0;
+    if (t > max) {
+      throw new AssertionError(
+        `Trace used ${t} tokens (expected ≤ ${max})`,
+        this.bundle.trace.id,
+        `toUseAtMostTokens(${max})`,
+      );
+    }
+  }
+
+  toHaveNoFailedSpans(): void {
+    const failed = this.bundle.spans.filter((s) => s.status === "failed");
+    if (failed.length > 0) {
+      throw new AssertionError(
+        `${failed.length} span(s) failed: ${failed.map((s) => s.name).join(", ")}`,
+        this.bundle.trace.id,
+        "toHaveNoFailedSpans()",
+      );
+    }
+  }
+
+  toHaveNoToolLoops(threshold = 3): void {
+    // A "loop" = the same tool called >= threshold consecutive times.
+    const toolSpans = this.bundle.spans.filter((s) => s.type === "tool");
+    let run = 1;
+    for (let i = 1; i < toolSpans.length; i++) {
+      if (toolSpans[i].toolName && toolSpans[i].toolName === toolSpans[i - 1].toolName) {
+        run++;
+        if (run >= threshold) {
+          throw new AssertionError(
+            `Tool '${toolSpans[i].toolName}' called ${run}x in a row (loop detected)`,
+            this.bundle.trace.id,
+            `toHaveNoToolLoops(${threshold})`,
+          );
+        }
+      } else {
+        run = 1;
+      }
+    }
+  }
+
+  toCallTool(name: string): ToolAssertion {
+    return new ToolAssertion(this.bundle, name);
+  }
+
+  toMatchOutput(matcher: RegExp | string): void {
+    const output = this.bundle.trace.output ?? "";
+    const ok = typeof matcher === "string" ? output.includes(matcher) : matcher.test(output);
+    if (!ok) {
+      throw new AssertionError(
+        `Trace output did not match ${matcher}`,
+        this.bundle.trace.id,
+        `toMatchOutput(${matcher})`,
+      );
+    }
+  }
+}
+
+export function expect(bundle: TraceBundle): TraceAssertion {
+  return new TraceAssertion(bundle);
+}
+
+export interface EvaluateOptions {
+  baseUrl: string;
+  name?: string;
+  projectId?: string;
+  limit?: number;
+  status?: "completed" | "failed" | "running" | "cancelled";
+  /** Restrict to traces from a specific commit (prefix match). */
+  gitCommit?: string;
+  /** Explicit trace IDs (overrides list fetching). */
+  traceIds?: string[];
+}
+
+export interface EvalResult {
+  total: number;
+  passed: number;
+  failed: number;
+  failures: Array<{ traceId: string; rule: string; message: string }>;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${url} responded ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+export async function evaluate(
+  options: EvaluateOptions,
+  assertions: (bundle: TraceBundle) => void | Promise<void>,
+): Promise<EvalResult> {
+  const base = options.baseUrl.replace(/\/$/, "");
+
+  let ids: string[];
+  if (options.traceIds && options.traceIds.length > 0) {
+    ids = options.traceIds;
+  } else {
+    const qs = new URLSearchParams();
+    if (options.name) qs.set("name", options.name);
+    if (options.projectId) qs.set("projectId", options.projectId);
+    if (options.status) qs.set("status", options.status);
+    qs.set("limit", String(options.limit ?? 20));
+    const list = await fetchJson<{ traces: TraceRecord[] }>(`${base}/v1/traces?${qs.toString()}`);
+    ids = list.traces
+      .filter((t) => (options.gitCommit ? (t.gitCommit || "").startsWith(options.gitCommit) : true))
+      .map((t) => t.id);
+  }
+
+  const failures: EvalResult["failures"] = [];
+  let passed = 0;
+
+  for (const id of ids) {
+    const bundle = await fetchJson<TraceBundle>(`${base}/v1/traces/${id}`);
+    try {
+      await assertions(bundle);
+      passed++;
+    } catch (err) {
+      if (err instanceof AssertionError) {
+        failures.push({ traceId: err.traceId, rule: err.rule, message: err.message });
+      } else {
+        failures.push({ traceId: id, rule: "(thrown)", message: String(err) });
+      }
+    }
+  }
+
+  return {
+    total: ids.length,
+    passed,
+    failed: failures.length,
+    failures,
+  };
+}

--- a/packages/eval/tsconfig.json
+++ b/packages/eval/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- New workspace package \`@pathlight/eval\` with matchers for latency, cost, tokens, tool-loop detection, and tool-call counts
- \`pathlight-eval\` CLI: \`pathlight-eval specs/foo.mjs --base-url http://localhost:4100\`
- Example spec + README with GitHub Actions snippet

## Why
Closes #9. Bridges observability → regression testing. With git-linked traces from #8, a single CI step answers "did my PR regress the agent?"

## Test plan
- [ ] \`npx turbo build\` succeeds
- [ ] \`node packages/eval/bin/pathlight-eval.js --help\` prints usage
- [ ] Run the example spec against a live collector, confirm pass/fail output and exit codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)