### PR TITLE
feat(#13): live breakpoints — pause agents and resume with edits

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import "./globals.css";
+import { BreakpointsPanel } from "../components/BreakpointsPanel";
 
 export const metadata: Metadata = {
   title: "Pathlight",
@@ -41,6 +42,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Sidebar />
           <main className="flex-1 ml-52">{children}</main>
         </div>
+        <BreakpointsPanel />
       </body>
     </html>
   );

--- a/apps/web/src/components/BreakpointsPanel.tsx
+++ b/apps/web/src/components/BreakpointsPanel.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import Link from "next/link";
+import { COLLECTOR_URL } from "../lib/api";
+
+interface Breakpoint {
+  id: string;
+  label: string;
+  traceId: string | null;
+  spanId: string | null;
+  state: unknown;
+  createdAt: string;
+}
+
+export function BreakpointsPanel() {
+  const [breakpoints, setBreakpoints] = useState<Breakpoint[]>([]);
+  const [open, setOpen] = useState(false);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const retryRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    let source: EventSource | null = null;
+
+    const connect = () => {
+      source = new EventSource(`${COLLECTOR_URL}/v1/breakpoints/stream`);
+
+      source.addEventListener("snapshot", (e) => {
+        try {
+          const data = JSON.parse((e as MessageEvent).data) as { breakpoints: Breakpoint[] };
+          setBreakpoints(data.breakpoints);
+        } catch {}
+      });
+      source.addEventListener("added", (e) => {
+        try {
+          const bp = JSON.parse((e as MessageEvent).data) as Breakpoint;
+          setBreakpoints((prev) => (prev.some((p) => p.id === bp.id) ? prev : [...prev, bp]));
+          // Auto-open the panel when a new breakpoint arrives.
+          setOpen(true);
+        } catch {}
+      });
+      const removeById = (id: string) => setBreakpoints((prev) => prev.filter((p) => p.id !== id));
+      source.addEventListener("resolved", (e) => {
+        try {
+          const { id } = JSON.parse((e as MessageEvent).data) as { id: string };
+          removeById(id);
+          setActiveId((a) => (a === id ? null : a));
+        } catch {}
+      });
+      source.addEventListener("cancelled", (e) => {
+        try {
+          const { id } = JSON.parse((e as MessageEvent).data) as { id: string };
+          removeById(id);
+          setActiveId((a) => (a === id ? null : a));
+        } catch {}
+      });
+      source.onerror = () => {
+        source?.close();
+        // Reconnect after a short backoff — the collector may have restarted.
+        retryRef.current = setTimeout(connect, 2000);
+      };
+    };
+
+    connect();
+    return () => {
+      if (retryRef.current) clearTimeout(retryRef.current);
+      source?.close();
+    };
+  }, []);
+
+  if (breakpoints.length === 0 && !open) return null;
+
+  const active = breakpoints.find((b) => b.id === activeId) ?? breakpoints[0] ?? null;
+
+  return (
+    <>
+      {/* Floating badge */}
+      {!open && breakpoints.length > 0 && (
+        <button
+          onClick={() => setOpen(true)}
+          className="fixed bottom-6 right-6 z-40 flex items-center gap-2 px-4 py-2.5 rounded-full bg-amber-500 hover:bg-amber-400 text-black font-medium shadow-2xl text-sm animate-pulse"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          {breakpoints.length} paused
+        </button>
+      )}
+
+      {/* Panel */}
+      {open && (
+        <div className="fixed bottom-6 right-6 z-40 w-[520px] max-h-[80vh] bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl flex flex-col">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+            <div className="flex items-center gap-2">
+              <svg className="w-4 h-4 text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <h2 className="text-sm font-semibold">Breakpoints</h2>
+              <span className="text-xs text-zinc-500">{breakpoints.length}</span>
+            </div>
+            <button
+              onClick={() => setOpen(false)}
+              className="text-zinc-500 hover:text-zinc-300"
+              aria-label="Close breakpoint panel"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {breakpoints.length === 0 ? (
+            <p className="text-xs text-zinc-500 px-4 py-6 text-center">No paused breakpoints.</p>
+          ) : (
+            <div className="flex flex-1 overflow-hidden">
+              <ul className="w-48 border-r border-zinc-800 overflow-y-auto">
+                {breakpoints.map((bp) => (
+                  <li key={bp.id}>
+                    <button
+                      onClick={() => setActiveId(bp.id)}
+                      className={`w-full text-left px-3 py-2.5 text-xs transition-colors ${
+                        (active?.id === bp.id) ? "bg-zinc-800 text-zinc-100" : "text-zinc-400 hover:bg-zinc-800/50"
+                      }`}
+                    >
+                      <span className="block font-medium truncate">{bp.label}</span>
+                      <span className="block text-[10px] text-zinc-600 font-mono mt-0.5">{bp.id.slice(0, 10)}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <div className="flex-1 overflow-y-auto">
+                {active && <BreakpointDetail bp={active} />}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+function BreakpointDetail({ bp }: { bp: Breakpoint }) {
+  const initial = JSON.stringify(bp.state, null, 2);
+  const [draft, setDraft] = useState(initial);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Keep the editor in sync when the selected breakpoint changes.
+  useEffect(() => {
+    setDraft(JSON.stringify(bp.state, null, 2));
+    setError(null);
+  }, [bp.id, bp.state]);
+
+  const resume = async (overrideState?: unknown) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const body = overrideState === undefined
+        ? { state: JSON.parse(draft) }
+        : { state: overrideState };
+      const res = await fetch(`${COLLECTOR_URL}/v1/breakpoints/${bp.id}/resume`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const cancel = async () => {
+    setBusy(true);
+    try {
+      await fetch(`${COLLECTOR_URL}/v1/breakpoints/${bp.id}/cancel`, { method: "POST" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-3 text-xs">
+      <div>
+        <p className="text-[10px] text-zinc-500 uppercase tracking-widest mb-1">Label</p>
+        <p className="text-zinc-200 font-medium">{bp.label}</p>
+      </div>
+      {bp.traceId && (
+        <div>
+          <p className="text-[10px] text-zinc-500 uppercase tracking-widest mb-1">Trace</p>
+          <Link href={`/traces/${bp.traceId}`} className="text-blue-400 hover:underline font-mono">
+            {bp.traceId}
+          </Link>
+        </div>
+      )}
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <p className="text-[10px] text-zinc-500 uppercase tracking-widest">State (editable)</p>
+          <button
+            onClick={() => setDraft(initial)}
+            className="text-[10px] text-zinc-500 hover:text-zinc-300"
+          >
+            Reset
+          </button>
+        </div>
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          spellCheck={false}
+          className="w-full h-48 bg-zinc-950 border border-zinc-800 rounded-md p-2 font-mono text-xs text-zinc-200 focus:outline-none focus:border-blue-500"
+        />
+        {error && <p className="text-red-400 text-[11px] mt-1">{error}</p>}
+      </div>
+      <div className="flex items-center gap-2 pt-2">
+        <button
+          disabled={busy}
+          onClick={() => resume(bp.state)}
+          className="px-3 py-1.5 rounded-md bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-xs disabled:opacity-50"
+        >
+          Resume as-is
+        </button>
+        <button
+          disabled={busy}
+          onClick={() => resume()}
+          className="px-3 py-1.5 rounded-md bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium disabled:opacity-50"
+        >
+          Resume with edits
+        </button>
+        <button
+          disabled={busy}
+          onClick={cancel}
+          className="ml-auto px-3 py-1.5 rounded-md text-xs text-red-400 hover:bg-red-950/40 disabled:opacity-50"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,6 @@
 "use client";
 
-const COLLECTOR_URL = process.env.NEXT_PUBLIC_COLLECTOR_URL || "http://localhost:4100";
+export const COLLECTOR_URL = process.env.NEXT_PUBLIC_COLLECTOR_URL || "http://localhost:4100";
 
 export async function fetchApi<T>(path: string): Promise<T> {
   const res = await fetch(`${COLLECTOR_URL}${path}`);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pathlight",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "npm@10.9.7",
   "description": "Visual debugging, execution traces, and observability for AI agents",
   "workspaces": [
     "packages/*",

--- a/packages/collector/src/breakpoints.ts
+++ b/packages/collector/src/breakpoints.ts
@@ -1,0 +1,68 @@
+import { EventEmitter } from "node:events";
+import { nanoid } from "nanoid";
+
+export interface Breakpoint {
+  id: string;
+  label: string;
+  traceId: string | null;
+  spanId: string | null;
+  state: unknown;
+  createdAt: string;
+}
+
+interface InternalBreakpoint extends Breakpoint {
+  resolve: (resumeState: unknown) => void;
+  reject: (err: Error) => void;
+}
+
+const active = new Map<string, InternalBreakpoint>();
+export const breakpointEvents = new EventEmitter();
+breakpointEvents.setMaxListeners(100);
+
+export function listBreakpoints(): Breakpoint[] {
+  return Array.from(active.values()).map(({ resolve: _r, reject: _j, ...rest }) => rest);
+}
+
+export function registerBreakpoint(params: {
+  label: string;
+  traceId?: string | null;
+  spanId?: string | null;
+  state?: unknown;
+}): { id: string; wait: Promise<unknown> } {
+  const id = nanoid();
+  const record: Partial<InternalBreakpoint> = {
+    id,
+    label: params.label,
+    traceId: params.traceId || null,
+    spanId: params.spanId || null,
+    state: params.state ?? null,
+    createdAt: new Date().toISOString(),
+  };
+
+  const wait = new Promise<unknown>((resolve, reject) => {
+    record.resolve = resolve;
+    record.reject = reject;
+  });
+
+  active.set(id, record as InternalBreakpoint);
+  breakpointEvents.emit("added", record as Breakpoint);
+  return { id, wait };
+}
+
+export function resumeBreakpoint(id: string, state: unknown): boolean {
+  const bp = active.get(id);
+  if (!bp) return false;
+  active.delete(id);
+  bp.resolve(state);
+  breakpointEvents.emit("resolved", { id, state });
+  return true;
+}
+
+export function cancelBreakpoint(id: string, reason: string): boolean {
+  const bp = active.get(id);
+  if (!bp) return false;
+  active.delete(id);
+  bp.reject(new Error(reason));
+  breakpointEvents.emit("cancelled", { id, reason });
+  return true;
+}

--- a/packages/collector/src/router.ts
+++ b/packages/collector/src/router.ts
@@ -4,6 +4,7 @@ import type { Db } from "@pathlight/db";
 import { createTraceRoutes } from "./routes/traces.js";
 import { createSpanRoutes } from "./routes/spans.js";
 import { createProjectRoutes } from "./routes/projects.js";
+import { createBreakpointRoutes } from "./routes/breakpoints.js";
 
 interface RouterContext {
   db: Db;
@@ -22,6 +23,7 @@ export async function createRouter(ctx: RouterContext) {
   app.route("/v1/traces", createTraceRoutes(ctx.db));
   app.route("/v1/spans", createSpanRoutes(ctx.db));
   app.route("/v1/projects", createProjectRoutes(ctx.db));
+  app.route("/v1/breakpoints", createBreakpointRoutes());
 
   // Health check
   app.get("/health", (c) => c.json({ status: "ok", service: "pathlight-collector" }));

--- a/packages/collector/src/routes/breakpoints.ts
+++ b/packages/collector/src/routes/breakpoints.ts
@@ -1,0 +1,115 @@
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import {
+  listBreakpoints,
+  registerBreakpoint,
+  resumeBreakpoint,
+  cancelBreakpoint,
+  breakpointEvents,
+  type Breakpoint,
+} from "../breakpoints.js";
+
+export function createBreakpointRoutes() {
+  const app = new Hono();
+
+  // Register and block on a breakpoint. Held open until the UI calls /resume,
+  // which responds with the (possibly-modified) state the SDK should continue
+  // with. Timeout of 15m prevents wedged SDK processes from holding a request
+  // open forever.
+  app.post("/", async (c) => {
+    const body = await c.req.json<{
+      label?: string;
+      traceId?: string;
+      spanId?: string;
+      state?: unknown;
+      timeoutMs?: number;
+    }>();
+
+    const { id, wait } = registerBreakpoint({
+      label: body.label || "(unnamed)",
+      traceId: body.traceId,
+      spanId: body.spanId,
+      state: body.state ?? null,
+    });
+
+    const timeoutMs = Math.min(Math.max(body.timeoutMs ?? 15 * 60_000, 1_000), 60 * 60_000);
+    const timeoutHandle = setTimeout(() => {
+      cancelBreakpoint(id, "timeout");
+    }, timeoutMs);
+
+    try {
+      const state = await wait;
+      clearTimeout(timeoutHandle);
+      return c.json({ id, resumed: true, state });
+    } catch (err) {
+      clearTimeout(timeoutHandle);
+      return c.json(
+        { id, resumed: false, error: err instanceof Error ? err.message : "unknown" },
+        408,
+      );
+    }
+  });
+
+  app.get("/", (c) => {
+    return c.json({ breakpoints: listBreakpoints() });
+  });
+
+  app.post("/:id/resume", async (c) => {
+    const id = c.req.param("id");
+    const body = await c.req.json<{ state?: unknown }>().catch(() => ({ state: undefined }));
+    const ok = resumeBreakpoint(id, body.state);
+    if (!ok) return c.json({ error: "breakpoint not found" }, 404);
+    return c.json({ resumed: true });
+  });
+
+  app.post("/:id/cancel", (c) => {
+    const id = c.req.param("id");
+    const ok = cancelBreakpoint(id, "cancelled by user");
+    if (!ok) return c.json({ error: "breakpoint not found" }, 404);
+    return c.json({ cancelled: true });
+  });
+
+  app.get("/stream", (c) => {
+    return streamSSE(c, async (stream) => {
+      // Send initial snapshot so the dashboard doesn't have to poll once on load.
+      await stream.writeSSE({
+        event: "snapshot",
+        data: JSON.stringify({ breakpoints: listBreakpoints() }),
+      });
+
+      const onAdded = (bp: Breakpoint) => {
+        stream.writeSSE({ event: "added", data: JSON.stringify(bp) }).catch(() => {});
+      };
+      const onResolved = (payload: { id: string }) => {
+        stream.writeSSE({ event: "resolved", data: JSON.stringify(payload) }).catch(() => {});
+      };
+      const onCancelled = (payload: { id: string; reason: string }) => {
+        stream.writeSSE({ event: "cancelled", data: JSON.stringify(payload) }).catch(() => {});
+      };
+      breakpointEvents.on("added", onAdded);
+      breakpointEvents.on("resolved", onResolved);
+      breakpointEvents.on("cancelled", onCancelled);
+
+      const heartbeat = setInterval(() => {
+        stream.writeSSE({ event: "ping", data: "" }).catch(() => {});
+      }, 25_000);
+
+      stream.onAbort(() => {
+        clearInterval(heartbeat);
+        breakpointEvents.off("added", onAdded);
+        breakpointEvents.off("resolved", onResolved);
+        breakpointEvents.off("cancelled", onCancelled);
+      });
+
+      while (!stream.aborted) {
+        await stream.sleep(60_000);
+      }
+      clearInterval(heartbeat);
+      breakpointEvents.off("added", onAdded);
+      breakpointEvents.off("resolved", onResolved);
+      breakpointEvents.off("cancelled", onCancelled);
+    });
+  });
+
+  return app;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -87,6 +87,48 @@ export class Pathlight {
     return new Trace(this, name, input, options);
   }
 
+  /**
+   * Register a live breakpoint that pauses execution until the dashboard
+   * resumes it. Returns the (possibly-modified) state the caller passed in.
+   *
+   * Typical use:
+   *
+   *   const state = await tl.breakpoint({
+   *     label: "post-retrieval",
+   *     state: { docs, query },
+   *   });
+   *
+   * If the dashboard edits `state` before resuming, the edited value is what
+   * the promise resolves to — so downstream code sees the override.
+   */
+  async breakpoint<T = unknown>(options: {
+    label: string;
+    state?: T;
+    traceId?: string;
+    spanId?: string;
+    /** Maximum time to wait before auto-resuming with the original state. */
+    timeoutMs?: number;
+  }): Promise<T> {
+    const res = await fetch(`${this.baseUrl}/v1/breakpoints`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        label: options.label,
+        state: options.state ?? null,
+        traceId: options.traceId,
+        spanId: options.spanId,
+        timeoutMs: options.timeoutMs,
+      }),
+    });
+
+    if (res.status === 408 || !res.ok) {
+      // Auto-resume on timeout or error — don't wedge the caller.
+      return (options.state as T) ?? (null as unknown as T);
+    }
+    const body = (await res.json()) as { state?: T };
+    return (body.state ?? (options.state as T)) as T;
+  }
+
   /** @internal */
   async _createTrace(data: { name: string; projectId?: string; input?: unknown; tags?: string[]; metadata?: unknown }) {
     return this.post("/v1/traces", { ...data, projectId: data.projectId || this.projectId });


### PR DESCRIPTION
## Summary
- SDK: \`await pathlight.breakpoint({ label, state })\` blocks until resumed
- Collector: in-memory registry, register+wait endpoint, resume/cancel, SSE stream
- Dashboard: floating amber badge + slide-out JSON editor, auto-opens on new pause

## Why
Closes #13. Turns Pathlight into a debugger, not just an observability tool. Drop a breakpoint anywhere in your agent, inspect and edit state on the dashboard, and resume — exactly what \`pdb\` does for Python, now for agent flows.

## Smoke test
Confirmed end-to-end via curl:
- POST /v1/breakpoints with state \`{x:1,y:"hello"}\`
- GET /v1/breakpoints lists it
- POST /:id/resume with \`{x:999,y:"resumed!"}\`
- Blocked registration response returns with the overridden state

## Test plan
- [ ] \`npx turbo build\` succeeds
- [ ] \`npx turbo dev\`, then call \`await tl.breakpoint({ label: "test", state: { x: 1 }})\` from any SDK script
- [ ] Dashboard shows the floating badge and auto-opens the panel
- [ ] Edit JSON state, click "Resume with edits" — SDK continues with edited value
- [ ] "Cancel" rejects the SDK promise with a 408
- [ ] 15-minute default timeout auto-resumes with original state if nothing is clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)