### PR TITLE
feat(#15): replay LLM spans with edited prompts

### DIFF
--- a/apps/web/src/app/traces/[id]/page.tsx
+++ b/apps/web/src/app/traces/[id]/page.tsx
@@ -191,7 +191,182 @@ function SpanInspector({ span, onClose }: { span: Span; onClose: () => void }) {
         <JsonBlock data={parseJson(span.toolArgs)} label="Tool Arguments" />
         <JsonBlock data={parseJson(span.toolResult)} label="Tool Result" />
         <JsonBlock data={parseJson(span.metadata)} label="Metadata" />
+
+        {span.type === "llm" && <ReplayPanel span={span} />}
       </div>
+    </div>
+  );
+}
+
+interface ReplayMessage { role: string; content: string }
+
+function extractMessages(span: Span): { messages: ReplayMessage[]; system?: string } {
+  const parsed = parseJson(span.input);
+  if (parsed && typeof parsed === "object" && "messages" in parsed && Array.isArray((parsed as { messages: unknown }).messages)) {
+    const p = parsed as { messages: ReplayMessage[]; system?: string };
+    const all = p.messages;
+    const system = p.system || (all[0]?.role === "system" ? String(all[0].content) : undefined);
+    const messages = all[0]?.role === "system" ? all.slice(1) : all;
+    return { messages, system };
+  }
+  // Fall back: treat input as a single user message
+  const content = typeof parsed === "string" ? parsed : JSON.stringify(parsed, null, 2);
+  return { messages: [{ role: "user", content }] };
+}
+
+function ReplayPanel({ span }: { span: Span }) {
+  const initial = extractMessages(span);
+  const [messages, setMessages] = useState<ReplayMessage[]>(initial.messages);
+  const [system, setSystem] = useState<string>(initial.system ?? "");
+  const [model, setModel] = useState(span.model ?? "");
+  const [apiKey, setApiKey] = useState<string>("");
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<{ output: string; durationMs: number; tokens?: string; error?: string } | null>(null);
+
+  const COLLECTOR_URL = process.env.NEXT_PUBLIC_COLLECTOR_URL || "http://localhost:4100";
+
+  useEffect(() => {
+    // Load stored API key if present (scoped per provider).
+    const provider = (span.provider || "openai").toLowerCase();
+    const stored = typeof window !== "undefined" ? localStorage.getItem(`pathlight:replay-key:${provider}`) : null;
+    if (stored) setApiKey(stored);
+  }, [span.provider]);
+
+  // Keep the editor fresh when jumping between spans.
+  useEffect(() => {
+    const next = extractMessages(span);
+    setMessages(next.messages);
+    setSystem(next.system ?? "");
+    setModel(span.model ?? "");
+    setResult(null);
+  }, [span.id, span.model]);
+
+  const provider = (span.provider || "openai").toLowerCase();
+
+  const run = async () => {
+    if (apiKey) {
+      localStorage.setItem(`pathlight:replay-key:${provider}`, apiKey);
+    }
+    setRunning(true);
+    setResult(null);
+    try {
+      const res = await fetch(`${COLLECTOR_URL}/v1/replay/llm`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider,
+          model,
+          system: system || undefined,
+          messages,
+          apiKey: apiKey || undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setResult({ output: "", durationMs: 0, error: JSON.stringify(data.error || data, null, 2) });
+      } else {
+        setResult({
+          output: data.output || "",
+          durationMs: data.durationMs || 0,
+          tokens: data.inputTokens ? `${data.inputTokens}/${data.outputTokens || 0}` : undefined,
+        });
+      }
+    } catch (err) {
+      setResult({ output: "", durationMs: 0, error: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="pt-4 border-t border-zinc-800">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-[10px] text-zinc-600 uppercase tracking-widest">Replay</p>
+        <span className="text-[10px] text-zinc-600">{provider}</span>
+      </div>
+
+      <div className="space-y-2">
+        <input
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          placeholder="model"
+          className="w-full bg-zinc-800/50 border border-zinc-700 rounded px-2 py-1 text-xs font-mono text-zinc-200"
+        />
+        {system !== undefined && (
+          <textarea
+            value={system}
+            onChange={(e) => setSystem(e.target.value)}
+            placeholder="system prompt (optional)"
+            rows={2}
+            className="w-full bg-zinc-800/50 border border-zinc-700 rounded px-2 py-1 text-xs font-mono text-zinc-300"
+          />
+        )}
+        {messages.map((m, i) => (
+          <div key={i} className="border border-zinc-700 rounded">
+            <div className="flex items-center justify-between px-2 py-1 bg-zinc-800/50">
+              <select
+                value={m.role}
+                onChange={(e) => setMessages(messages.map((mm, idx) => (idx === i ? { ...mm, role: e.target.value } : mm)))}
+                className="bg-zinc-800 border border-zinc-700 rounded text-[10px] px-1 py-0.5 text-zinc-300"
+              >
+                <option value="user">user</option>
+                <option value="assistant">assistant</option>
+                <option value="system">system</option>
+              </select>
+              <button
+                onClick={() => setMessages(messages.filter((_, idx) => idx !== i))}
+                className="text-[10px] text-zinc-500 hover:text-red-400"
+              >
+                remove
+              </button>
+            </div>
+            <textarea
+              value={m.content}
+              onChange={(e) => setMessages(messages.map((mm, idx) => (idx === i ? { ...mm, content: e.target.value } : mm)))}
+              rows={Math.min(8, Math.max(2, m.content.split("\n").length))}
+              className="w-full bg-zinc-900 px-2 py-1 text-xs font-mono text-zinc-200 border-t border-zinc-700 focus:outline-none"
+            />
+          </div>
+        ))}
+        <button
+          onClick={() => setMessages([...messages, { role: "user", content: "" }])}
+          className="text-[10px] text-zinc-500 hover:text-zinc-300"
+        >
+          + add message
+        </button>
+
+        <input
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder={`${provider} api key (saved locally; collector env var also works)`}
+          className="w-full bg-zinc-800/50 border border-zinc-700 rounded px-2 py-1 text-xs font-mono text-zinc-200"
+        />
+
+        <button
+          onClick={run}
+          disabled={running || !model}
+          className="w-full bg-blue-600 hover:bg-blue-500 disabled:bg-zinc-800 disabled:text-zinc-500 text-white text-xs font-medium px-3 py-2 rounded transition-colors"
+        >
+          {running ? "Running…" : "Run replay"}
+        </button>
+      </div>
+
+      {result && (
+        <div className="mt-3 space-y-1">
+          <div className="flex items-center justify-between text-[10px] text-zinc-600 uppercase tracking-widest">
+            <span>Replay output</span>
+            <span>
+              {result.durationMs}ms{result.tokens ? ` · ${result.tokens} tok` : ""}
+            </span>
+          </div>
+          {result.error ? (
+            <pre className="bg-red-950/40 border border-red-800/50 rounded p-2 text-[11px] text-red-300 whitespace-pre-wrap max-h-40 overflow-y-auto">{result.error}</pre>
+          ) : (
+            <pre className="bg-zinc-800/50 border border-zinc-700/50 rounded p-2 text-[11px] text-zinc-200 whitespace-pre-wrap font-mono max-h-60 overflow-y-auto">{result.output}</pre>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pathlight",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "npm@10.9.7",
   "description": "Visual debugging, execution traces, and observability for AI agents",
   "workspaces": [
     "packages/*",

--- a/packages/collector/src/router.ts
+++ b/packages/collector/src/router.ts
@@ -4,6 +4,7 @@ import type { Db } from "@pathlight/db";
 import { createTraceRoutes } from "./routes/traces.js";
 import { createSpanRoutes } from "./routes/spans.js";
 import { createProjectRoutes } from "./routes/projects.js";
+import { createReplayRoutes } from "./routes/replay.js";
 
 interface RouterContext {
   db: Db;
@@ -22,6 +23,7 @@ export async function createRouter(ctx: RouterContext) {
   app.route("/v1/traces", createTraceRoutes(ctx.db));
   app.route("/v1/spans", createSpanRoutes(ctx.db));
   app.route("/v1/projects", createProjectRoutes(ctx.db));
+  app.route("/v1/replay", createReplayRoutes());
 
   // Health check
   app.get("/health", (c) => c.json({ status: "ok", service: "pathlight-collector" }));

--- a/packages/collector/src/routes/replay.ts
+++ b/packages/collector/src/routes/replay.ts
@@ -1,0 +1,103 @@
+import { Hono } from "hono";
+
+/**
+ * Server-side proxy that lets the dashboard re-run an LLM call with edited
+ * inputs. The browser can't call OpenAI/Anthropic directly (CORS) so the
+ * request flows through the collector. API keys are read from env vars
+ * (OPENAI_API_KEY, ANTHROPIC_API_KEY) by default, but the request can
+ * override them per-call for quick experimentation.
+ */
+export function createReplayRoutes() {
+  const app = new Hono();
+
+  app.post("/llm", async (c) => {
+    const body = await c.req.json<{
+      provider: "openai" | "anthropic" | string;
+      model: string;
+      messages: Array<{ role: string; content: string | Array<unknown> }>;
+      system?: string;
+      temperature?: number;
+      maxTokens?: number;
+      apiKey?: string;
+      baseUrl?: string;
+    }>();
+
+    if (!body.provider || !body.model || !Array.isArray(body.messages)) {
+      return c.json({ error: "provider, model, and messages are required" }, 400);
+    }
+
+    const started = Date.now();
+
+    try {
+      if (body.provider === "anthropic") {
+        const apiKey = body.apiKey || process.env.ANTHROPIC_API_KEY;
+        if (!apiKey) return c.json({ error: "ANTHROPIC_API_KEY not set and no apiKey in request" }, 400);
+
+        const base = body.baseUrl || "https://api.anthropic.com";
+        const res = await fetch(`${base}/v1/messages`, {
+          method: "POST",
+          headers: {
+            "x-api-key": apiKey,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            model: body.model,
+            max_tokens: body.maxTokens ?? 1024,
+            system: body.system,
+            messages: body.messages,
+            temperature: body.temperature,
+          }),
+        });
+        const data = await res.json();
+        if (!res.ok) return c.json({ error: data }, 502);
+        return c.json({
+          provider: "anthropic",
+          model: data.model,
+          output: data.content?.map((c: { text?: string }) => c.text).filter(Boolean).join("\n") || "",
+          raw: data,
+          inputTokens: data.usage?.input_tokens,
+          outputTokens: data.usage?.output_tokens,
+          durationMs: Date.now() - started,
+        });
+      }
+
+      // OpenAI-compatible (OpenAI, Ollama, Together, Groq, etc)
+      const apiKey = body.apiKey || process.env.OPENAI_API_KEY;
+      const base = body.baseUrl || "https://api.openai.com";
+      const res = await fetch(`${base}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: body.model,
+          messages: body.system
+            ? [{ role: "system", content: body.system }, ...body.messages]
+            : body.messages,
+          temperature: body.temperature,
+          max_tokens: body.maxTokens,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) return c.json({ error: data }, 502);
+      return c.json({
+        provider: "openai",
+        model: data.model,
+        output: data.choices?.[0]?.message?.content ?? "",
+        raw: data,
+        inputTokens: data.usage?.prompt_tokens,
+        outputTokens: data.usage?.completion_tokens,
+        durationMs: Date.now() - started,
+      });
+    } catch (err) {
+      return c.json(
+        { error: err instanceof Error ? err.message : String(err) },
+        500,
+      );
+    }
+  });
+
+  return app;
+}


### PR DESCRIPTION
## Summary
- Collector: new \`POST /v1/replay/llm\` proxy for OpenAI-compatible + Anthropic chat APIs
- Dashboard: editable \`<ReplayPanel>\` in every LLM-span inspector — system prompt, message role + content, model
- Per-provider API key saved in localStorage; collector env-var fallback (\`OPENAI_API_KEY\`, \`ANTHROPIC_API_KEY\`)
- Inline response with token + duration

## Why
Closes #15. Turns every trace into a playground — tweak the prompt of a real production LLM call and re-run without copy-pasting to a separate tool.

## Scoping
LLM-span replay only. Tool and multi-span replay are follow-ups — they require re-entering user code, which needs SDK cooperation. This MVP covers the highest-leverage iteration loop (prompt tuning).

## Test plan
- [ ] \`npx turbo build\` succeeds
- [ ] Open a trace with an LLM span, set OPENAI_API_KEY in collector env
- [ ] Edit system prompt / add a user message / change model, click "Run replay"
- [ ] Verify response renders inline with tokens + duration
- [ ] Try Anthropic provider with \`ANTHROPIC_API_KEY\`
- [ ] Enter a wrong key → error JSON shown in red panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)