### PR TITLE
feat(web): horizontal top nav; drop left sidebar

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,47 +1,19 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import "./globals.css";
 import { BreakpointsPanel } from "../components/BreakpointsPanel";
+import { TopNav } from "../components/TopNav";
 
 export const metadata: Metadata = {
   title: "Pathlight",
   description: "Visual debugging and observability for AI agents",
 };
 
-function Sidebar() {
-  return (
-    <aside className="fixed top-0 left-0 h-screen w-52 bg-zinc-950 border-r border-zinc-800 flex flex-col z-50">
-      <div className="h-14 flex items-center px-5 border-b border-zinc-800">
-        <Link href="/" className="text-lg font-bold tracking-tight">
-          <span className="text-blue-400">Path</span>light
-        </Link>
-      </div>
-      <nav className="flex-1 px-3 py-4 space-y-1">
-        <Link
-          href="/"
-          className="flex items-center gap-2.5 px-2 py-1.5 rounded-md text-sm text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800/50 transition-colors"
-        >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z" />
-          </svg>
-          Traces
-        </Link>
-      </nav>
-      <div className="border-t border-zinc-800 px-4 py-3">
-        <p className="text-[10px] text-zinc-600">pathlight v0.1.0</p>
-      </div>
-    </aside>
-  );
-}
-
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body className="bg-zinc-950 text-zinc-100 antialiased">
-        <div className="flex min-h-screen">
-          <Sidebar />
-          <main className="flex-1 ml-52">{children}</main>
-        </div>
+        <TopNav />
+        <main>{children}</main>
         <BreakpointsPanel />
       </body>
     </html>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -121,17 +121,9 @@ function TracesPageInner() {
 
   return (
     <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">Traces</h1>
-          <p className="text-sm text-zinc-500 mt-1">{total} total trace{total !== 1 ? "s" : ""}</p>
-        </div>
-        <Link
-          href="/commits"
-          className="text-xs px-3 py-1.5 rounded-md bg-zinc-900 border border-zinc-800 text-zinc-300 hover:border-zinc-700 hover:text-zinc-100 transition-colors"
-        >
-          Commits →
-        </Link>
+      <div>
+        <h1 className="text-2xl font-bold">Traces</h1>
+        <p className="text-sm text-zinc-500 mt-1">{total} total trace{total !== 1 ? "s" : ""}</p>
       </div>
 
       <div className="flex items-center gap-3">

--- a/apps/web/src/components/TopNav.tsx
+++ b/apps/web/src/components/TopNav.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const LINKS = [
+  { href: "/", label: "Traces", match: (p: string) => p === "/" || p.startsWith("/traces") },
+  { href: "/commits", label: "Commits", match: (p: string) => p.startsWith("/commits") },
+];
+
+export function TopNav() {
+  const pathname = usePathname() || "/";
+
+  return (
+    <header className="sticky top-0 z-40 bg-zinc-950/90 backdrop-blur border-b border-zinc-800">
+      <div className="max-w-7xl mx-auto px-6 h-12 flex items-center gap-6">
+        <Link href="/" className="text-base font-bold tracking-tight shrink-0">
+          <span className="text-blue-400">Path</span>light
+        </Link>
+        <nav className="flex items-center gap-1">
+          {LINKS.map((l) => {
+            const active = l.match(pathname);
+            return (
+              <Link
+                key={l.href}
+                href={l.href}
+                className={`px-2.5 py-1 rounded-md text-sm transition-colors ${
+                  active
+                    ? "text-zinc-100 bg-zinc-800/60"
+                    : "text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800/30"
+                }`}
+              >
+                {l.label}
+              </Link>
+            );
+          })}
+        </nav>
+        <span className="ml-auto text-[10px] text-zinc-600 shrink-0">v0.1.0</span>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- New sticky \`<TopNav>\` with Traces + Commits links, logo, version tag
- Remove fixed 208px left Sidebar and the \`ml-52\` main offset
- Remove redundant "Commits →" button from the trace list header

## Why
With only two top-level pages, the left sidebar was wasting horizontal real estate — especially on the trace detail's side-by-side inspector view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)