### PR TITLE
docs: nav right-align + comprehensive documentation pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,103 @@
+# Changelog
+
+All notable changes to Pathlight. Dates are release days, not merge days.
+
+## Unreleased
+
+### Added — Real-time dashboard ([#3](https://github.com/syndicalt/pathlight/issues/3))
+- **SSE stream** at `GET /v1/traces/stream` broadcasts `trace.created` and
+  `trace.updated` events.
+- Dashboard subscribes on load; traces appear and update live without refresh.
+- **Unreviewed traces** get a subtle sky-blue left accent. Opening a trace
+  detail page auto-marks it reviewed via `PATCH /v1/traces/:id { reviewedAt }`.
+- `reviewed_at` column added to `traces`.
+
+### Added — Trace diff ([#5](https://github.com/syndicalt/pathlight/issues/5))
+- Select two traces on the list (hover-revealed checkboxes, floating Compare
+  action bar) and open `/traces/compare?a=…&b=…`.
+- LCS-aligned span pairs with per-pair duration delta.
+- Line-level JSON diff for trace inputs, outputs, and any expanded span's
+  input/output.
+- Summary deltas at top: duration / tokens / cost, span count.
+- Zero-dependency diff utility at `apps/web/src/lib/diff.ts`.
+
+### Added — Git-linked regressions ([#7](https://github.com/syndicalt/pathlight/issues/7))
+- SDK auto-captures commit SHA, branch, and dirty flag via `git rev-parse`
+  (once per process, cached). Opt-out: `new Pathlight({ disableGitContext: true })`.
+- New columns on `traces`: `git_commit`, `git_branch`, `git_dirty`.
+- `GET /v1/traces/commits` returns per-commit aggregates (trace count, avg
+  duration/tokens/cost, failure count, first/last seen).
+- New dashboard page `/commits` shows each commit with deltas vs. the previous
+  commit; regressions >25% highlighted red.
+- Commit badge on every trace row; `?commit=<sha>` filters the list.
+
+### Added — `@pathlight/eval` assertion DSL and CI runner ([#9](https://github.com/syndicalt/pathlight/issues/9))
+- New workspace package exposing pytest-style matchers:
+  - `toSucceed()` / `toFail()`
+  - `toCompleteWithin(ms | "5s" | "2m")`
+  - `toCostLessThan(usd)` / `toUseAtMostTokens(n)`
+  - `toHaveNoFailedSpans()` / `toHaveNoToolLoops(n?)`
+  - `toCallTool(name).atMost(n)` / `.atLeast(n)` / `.exactly(n)`
+  - `toMatchOutput(regex | string)`
+- `pathlight-eval <spec.mjs>` CLI. Exit code 0 on all pass; 1 with a failure
+  report on any miss; 2 on spec-loading errors.
+- Drop-in GitHub Actions step example in `packages/eval/README.md`.
+
+### Added — `pathlight share` single-file trace snapshot ([#11](https://github.com/syndicalt/pathlight/issues/11))
+- New workspace package `@pathlight/cli`.
+- `pathlight share <trace-id>` writes a self-contained HTML file with:
+  - Embedded trace data (JSON in a `<script type="application/json">`).
+  - Vanilla JS/CSS viewer: summary cards, input/output, waterfall timeline.
+  - Zero network calls on open; opens in any browser.
+- Redaction flags: `--redact-input`, `--redact-output`, `--redact-errors`.
+- `--base-url`, `--out` path options; `PATHLIGHT_URL` env var fallback.
+
+### Added — Live breakpoints ([#13](https://github.com/syndicalt/pathlight/issues/13))
+- `await pathlight.breakpoint({ label, state, timeoutMs? })` pauses the agent
+  and long-polls the collector until the dashboard resumes it.
+- If the dashboard edits `state` before resuming, the promise resolves with
+  the edited value.
+- In-memory registry on the collector with an `EventEmitter` backbone.
+- Routes:
+  - `POST /v1/breakpoints` — register + wait
+  - `GET /v1/breakpoints` — list active
+  - `POST /v1/breakpoints/:id/resume` — resume with optional override
+  - `POST /v1/breakpoints/:id/cancel` — reject the SDK promise
+  - `GET /v1/breakpoints/stream` — SSE feed (snapshot + added/resolved/cancelled)
+- Dashboard gets a floating amber pulse badge and a slide-out editor with:
+  - Label, source trace link, live JSON editor for the state
+  - "Resume as-is" / "Resume with edits" / "Cancel"
+  - Auto-opens on new breakpoint arrival
+
+### Added — LLM span replay ([#15](https://github.com/syndicalt/pathlight/issues/15))
+- Any LLM span inspector gets an inline playground:
+  - Editable model, system prompt, per-message role + content
+  - Add/remove messages
+  - API key field (saved in `localStorage` per-provider)
+  - "Run replay" posts to the collector which proxies to the real provider
+- `POST /v1/replay/llm` supports:
+  - OpenAI-compatible providers (OpenAI, Together, Groq, Ollama, …) via
+    `/v1/chat/completions`
+  - Anthropic via `/v1/messages`
+  - `apiKey` override per-request or `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`
+    env vars on the collector
+- Response renders inline with tokens + duration.
+
+### Changed — UI layout
+- **Span inspector** is now a side-by-side panel rather than a fixed overlay
+  sidebar — timeline narrows to the left (0.8fr), inspector takes the right
+  (1.2fr) and is sticky while scrolling. Non-LLM spans keep a two-column
+  JSON grid. ([#17](https://github.com/syndicalt/pathlight/issues/17), [#18](https://github.com/syndicalt/pathlight/issues/18), [#19](https://github.com/syndicalt/pathlight/issues/19))
+- **Top navigation** replaces the left sidebar. Sticky header with logo,
+  version, and Traces / Commits links right-aligned. Frees ~200px of
+  horizontal width on every page. ([#20](https://github.com/syndicalt/pathlight/issues/20))
+
+### Fixed
+- Trace list input preview: nested objects no longer render as
+  `[object Object]`. `Object.values(parsed)` now maps non-string values
+  through `JSON.stringify` before joining.
+
+## 0.1.0 — 2026-04-16
+
+Initial release. Core trace/span model, Hono collector, Next.js dashboard,
+TypeScript SDK, source-location capture, issue detection, `db:retire` CLI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,29 @@
 
 Visual debugging, execution traces, and observability for AI agents.
 
+See `README.md` for the user-facing overview, `CHANGELOG.md` for a
+feature-by-feature history, and `docs/` for per-feature deep-dives.
+
 ## Architecture
 
 Turborepo monorepo with npm workspaces:
 
-- `packages/collector` — Hono-based trace collector API on port 4100. Receives traces, spans, and events from the SDK.
-- `packages/db` — Drizzle ORM + SQLite. Schema: traces, spans, events, projects, scores.
-- `packages/sdk` — TypeScript SDK for instrumenting agents. Sends trace data to the collector.
-- `apps/web` — Next.js + Tailwind CSS dashboard for viewing and debugging traces.
+- `packages/collector` — Hono-based trace collector API on port 4100.
+  Receives traces/spans/events, serves SSE streams, proxies LLM replays,
+  hosts the in-memory breakpoint registry.
+- `packages/db` — Drizzle ORM + SQLite. Schema: traces, spans, events,
+  projects, scores. Traces carry `git_commit`/`git_branch`/`git_dirty` and
+  `reviewed_at`.
+- `packages/sdk` — TypeScript SDK for instrumenting agents. Auto-captures
+  source locations + git context. Exposes `tl.breakpoint()` for live
+  debugging.
+- `packages/eval` — `@pathlight/eval` assertion DSL and `pathlight-eval`
+  CI runner.
+- `packages/cli` — `@pathlight/cli` with `pathlight share` subcommand for
+  exporting single-file HTML trace snapshots.
+- `apps/web` — Next.js + Tailwind dashboard (port 3100). Routes: `/`
+  (list), `/traces/[id]` (detail + side-by-side inspector), `/traces/compare`
+  (diff), `/commits` (regression view).
 
 ## Commands
 
@@ -18,24 +33,32 @@ npx turbo dev               # Start collector + web concurrently
 npm run dev -w packages/collector   # Collector only (port 4100)
 npm run dev -w apps/web             # Web UI only (port 3100)
 
-# Database
-npm run db:generate -w packages/db   # Generate Drizzle migrations
-npm run db:migrate -w packages/db    # Run migrations
-npm run db:studio -w packages/db     # Open Drizzle Studio
-npm run db:retire -w packages/db                          # Archive default database
-npm run db:retire -w packages/db -- ../collector/pathlight.db  # Archive specific database
-npm run db:retire -w packages/db -- --delete              # Permanently delete instead
+# Database (the collector's DB is at packages/collector/pathlight.db)
+npm run db:generate -w packages/db
+DATABASE_URL="file:$(pwd)/packages/collector/pathlight.db" \
+  npm run db:migrate -w packages/db
+npm run db:studio -w packages/db
+npm run db:retire -w packages/db                          # Archive default DB
+npm run db:retire -w packages/db -- ../collector/pathlight.db  # Archive specific
+npm run db:retire -w packages/db -- --delete              # Delete instead
+
+# CLIs
+pathlight share <trace-id> --out ./snapshot.html
+pathlight-eval specs/estimate.mjs --base-url http://localhost:4100
 ```
 
-## Key Data Model
+## Key data model
 
-- **Trace** — A complete agent execution (one run). Has status, input/output, duration, total tokens/cost.
-- **Span** — A single step within a trace (LLM call, tool use, decision). Supports nesting via parentSpanId. Types: llm, tool, retrieval, agent, chain, custom.
-- **Event** — Point-in-time annotation within a span (logs, decisions, errors). Has severity levels.
-- **Score** — Quality annotation on a trace or span (human or auto-generated).
-- **Project** — Groups traces. Has an API key for SDK authentication.
+- **Trace** — A complete agent execution. Status, input/output, duration,
+  tokens, cost, git provenance, `reviewedAt`.
+- **Span** — A single step. Types: llm, tool, retrieval, agent, chain,
+  custom. Nests via `parentSpanId`.
+- **Event** — Point-in-time annotation within a span (logs, decisions,
+  errors).
+- **Score** — Quality annotation on a trace or span.
+- **Project** — Groups traces; has an API key for SDK auth.
 
-## SDK Usage
+## SDK usage
 
 ```typescript
 import { Pathlight } from "@pathlight/sdk";
@@ -47,4 +70,25 @@ const span = trace.span("llm.chat", "llm", { model: "gpt-4o" });
 // ... do work ...
 span.end({ output: result, inputTokens: 100, outputTokens: 200 });
 trace.end({ output: finalResult });
+
+// Pause mid-run; dashboard resumes with optional state override.
+const state = await tl.breakpoint({ label: "checkpoint", state: { foo } });
 ```
+
+## Notable UI conventions
+
+- **Top nav** (`apps/web/src/components/TopNav.tsx`) — sticky horizontal
+  header with logo, version, right-aligned page links. Replaces the old
+  fixed left sidebar.
+- **Span inspector** — side-by-side with the timeline when a span is
+  selected. Timeline narrows to `0.8fr`; inspector takes `1.2fr` and is
+  sticky.
+- **Breakpoints panel** (`BreakpointsPanel.tsx`) — globally mounted in
+  `layout.tsx`. Auto-opens on new breakpoint arrival.
+
+## Conventions
+
+- Commit messages use `feat(#N):` / `fix(#N):` / `refactor(web):` style.
+- Shiplog workflow: each feature gets an `issue/N-slug` branch and PR.
+- Keep the collector DB migrated (`DATABASE_URL` must point at
+  `packages/collector/pathlight.db` for CLI migrations).

--- a/README.md
+++ b/README.md
@@ -2,45 +2,57 @@
 
 Visual debugging, execution traces, and observability for AI agents.
 
-When your AI agent makes a bad decision at step 7 of a 12-step workflow, Pathlight shows you exactly what happened — what went in, what came out, how long it took, and where in your code it was called. No more debugging agents with `console.log`.
+When your AI agent makes a bad decision at step 7 of a 12-step workflow,
+Pathlight shows you exactly what happened — what went in, what came out, how
+long it took, and where in your code it was called. Then it lets you *edit*
+that step's prompt and re-run it against the real model, diff two runs
+side-by-side, pause the agent mid-execution, or block a PR when latency
+regresses.
 
-## Features
+No more debugging agents with `console.log`.
 
-- **Waterfall Timeline** — See every step of your agent's execution as a visual timeline with proportional duration bars. LLM calls, tool invocations, retrieval steps — all in one view.
-- **Span Inspector** — Click any step to see full inputs, outputs, token counts, model used, and cost. JSON data is formatted and expandable.
-- **Automatic Source Mapping** — The SDK captures the exact file, line number, and function name where each span was created. Zero configuration required.
-- **Issue Detection** — Spans with failures, errors, or problems are automatically flagged with amber highlights. Traces with issues are marked in the list view so you can spot problems at a glance.
-- **Framework Agnostic** — Works with any AI agent, any LLM provider, any framework. Not tied to LangChain, CrewAI, or any specific tool.
-- **Self-Hosted** — Your trace data stays on your infrastructure. SQLite database, Docker deploy, no external dependencies.
+---
 
-## Quick Start
+## Feature tour
+
+| Feature | Why you'd use it | Docs |
+| --- | --- | --- |
+| **Waterfall timeline** | Visual answer to "where is the time going?" | [overview](#waterfall-timeline) |
+| **Span inspector** | Full input/output/metadata on click, side-by-side with timeline | [overview](#span-inspector) |
+| **Real-time stream** | New traces and status changes land without refresh | [docs/realtime.md](docs/realtime.md) |
+| **Trace diff** | Side-by-side compare of two traces; "did my prompt change break anything?" | [docs/trace-diff.md](docs/trace-diff.md) |
+| **Git-linked regressions** | SDK auto-captures commit SHA; `/commits` page flags >25% cost/latency regressions | [docs/git-regressions.md](docs/git-regressions.md) |
+| **Live breakpoints** | `await tl.breakpoint(...)` pauses your agent; edit state on the dashboard and resume | [docs/breakpoints.md](docs/breakpoints.md) |
+| **LLM replay** | Edit messages on any LLM span and re-run against the real provider | [docs/replay.md](docs/replay.md) |
+| **Eval-as-code + CI** | `expect(trace).toCostLessThan(0.10)` — assert over recent traces, exit nonzero in CI | [packages/eval/README.md](packages/eval/README.md) |
+| **`pathlight share`** | Single-file HTML snapshot of a trace, zero deps to open | [packages/cli/README.md](packages/cli/README.md) |
+| **Automatic source mapping** | Every span records the file:line where it was created | [overview](#automatic-source-mapping) |
+| **Issue detection** | Failed spans + error-pattern matches flag traces in the list | [overview](#issue-detection) |
+
+Full chronological list in [CHANGELOG.md](CHANGELOG.md).
+
+---
+
+## Quick start
 
 ```bash
 git clone https://github.com/syndicalt/pathlight.git
 cd pathlight
-
 npm install
 
-# Generate and run database migrations
+# Generate and apply database migrations
 npm run db:generate -w packages/db
-npm run db:migrate -w packages/db
+DATABASE_URL="file:$(pwd)/packages/collector/pathlight.db" \
+  npm run db:migrate -w packages/db
 
-# Start everything (collector + dashboard)
+# Start collector (4100) + dashboard (3100) together
 npx turbo dev
-
-# Archive database to start fresh (renames to .archived-<timestamp>.db)
-npm run db:retire -w packages/db -- ../collector/pathlight.db
-
-# Or permanently delete it
-npm run db:retire -w packages/db -- --delete ../collector/pathlight.db
 ```
 
-- **Collector**: http://localhost:4100 (receives trace data from your agent)
-- **Dashboard**: http://localhost:3100 (view and debug traces)
+- **Collector**: <http://localhost:4100> — receives trace data from your agent
+- **Dashboard**: <http://localhost:3100> — view, debug, diff, replay
 
-## Instrument Your Agent
-
-Add a few lines to your agent code. The SDK handles the rest.
+### Instrument your agent
 
 ```bash
 npm install @pathlight/sdk
@@ -49,138 +61,242 @@ npm install @pathlight/sdk
 ```typescript
 import { Pathlight } from "@pathlight/sdk";
 
-const tl = new Pathlight({
-  baseUrl: "http://localhost:4100",
-});
+const tl = new Pathlight({ baseUrl: "http://localhost:4100" });
 
-// Start a trace for an agent run
 const trace = tl.trace("research-agent", { query: "What is WebAssembly?" });
 
-// Wrap each step in a span
-const classifySpan = trace.span("classify", "llm", {
-  input: { prompt: "Classify this query..." },
-});
-const result = await llm.chat("Classify this query...");
-await classifySpan.end({
-  output: result,
-  inputTokens: 50,
-  outputTokens: 10,
-});
+// Each step is a span
+const llm = trace.span("classify", "llm", { model: "gpt-4o" });
+const result = await openai.chat(/* … */);
+await llm.end({ output: result, inputTokens: 50, outputTokens: 10 });
 
-// Tool calls
-const searchSpan = trace.span("web-search", "tool", {
-  toolName: "search",
-  toolArgs: { query: "WebAssembly" },
-});
-const results = await searchTool("WebAssembly");
-await searchSpan.end({ toolResult: results });
+const search = trace.span("web-search", "tool", { toolName: "search" });
+const results = await searchTool(result.query);
+await search.end({ toolResult: results });
 
-// End the trace
 await trace.end({ output: finalAnswer });
 ```
 
-That's it. Open http://localhost:3100 and you'll see the full execution timeline.
+That's it. Open the dashboard and every trace appears in real time with full
+waterfall, source locations, token counts, and git provenance.
 
-## Span Types
+---
 
-| Type | Color | Use For |
-|------|-------|---------|
+## Workflow playbooks
+
+### "Did my prompt change regress anything?"
+1. Open the trace list. Commit badge on each row shows which SHA produced it.
+2. Pick the last good run and your new run; click **Compare**.
+3. See per-span duration delta, input/output JSON diff, and new/missing spans.
+
+### "Can I stop this agent mid-flight and tweak its state?"
+1. Drop `state = await tl.breakpoint({ label: "post-retrieval", state: { docs, query } })`.
+2. Run the agent. When execution reaches the breakpoint, the dashboard's
+   floating pulse badge lights up.
+3. Edit the JSON state, click **Resume with edits** — your agent continues
+   with the modified value.
+
+### "Let me tune this prompt without leaving the dashboard."
+1. Open a trace detail, click any LLM span.
+2. Edit the system prompt, messages, or model right in the inspector.
+3. Enter your provider API key (saved in `localStorage` per-provider) and
+   click **Run replay**.
+
+### "Don't let a merge ship a cost regression."
+1. Write `specs/estimate.mjs` with `expect(trace).toCostLessThan(0.05)` etc.
+2. Add a GitHub Actions step: `npx pathlight-eval specs/estimate.mjs --base-url …`.
+3. Merge gate fails when any trace violates the assertion.
+
+### "Send this weird run to a teammate."
+1. `pathlight share <trace-id> --out /tmp/bad-run.html`
+2. Attach the HTML to your GitHub issue / Slack thread. They open it in any
+   browser — no dashboard, no server, no dependencies.
+
+---
+
+## What you see
+
+### Trace list
+
+All agent runs at a glance. Status, duration, tokens, tags, commit badge.
+Unreviewed runs get a subtle left accent. Real-time — new traces and status
+updates appear without refresh. Multi-select two rows to compare.
+
+### Waterfall timeline
+
+Every span as a proportional bar showing when it started and how long it
+took relative to the total trace. Sequential steps cascade down. Issue spans
+get an amber highlight. Clicking a span splits the view: timeline shrinks
+left, inspector fills the right.
+
+### Span inspector
+
+Side-by-side with the timeline. Shows:
+- Status, duration, model, provider, tokens
+- **Source location** — file:line automatically captured from the call stack
+- Input / output / tool args / tool result / metadata (formatted JSON)
+- Error details
+- For **LLM spans**: full replay editor — edit messages and re-run
+
+### `/commits` regression view
+
+Groups recent traces by commit SHA. Per-commit aggregates (trace count, avg
+duration/tokens/cost, failure count) with deltas vs. the previous commit.
+Rows where a metric got ≥25% worse are tinted red so regressions can't hide.
+
+### Breakpoints panel
+
+Floating amber pulse badge appears the moment any agent hits a breakpoint.
+Click it to open a per-breakpoint editor: label, trace link, live JSON state
+editor, Resume / Resume with edits / Cancel.
+
+---
+
+## Span types
+
+| Type | Color | Use for |
+| --- | --- | --- |
 | `llm` | Blue | LLM API calls (chat completions, embeddings) |
-| `tool` | Green | Tool invocations (search, code execution, API calls) |
-| `retrieval` | Violet | RAG retrieval, document fetching, knowledge base lookups |
+| `tool` | Green | Tool invocations (search, code exec, API calls) |
+| `retrieval` | Violet | RAG retrieval, document fetches, knowledge base lookups |
 | `agent` | Orange | Sub-agent invocations, delegation |
 | `chain` | Cyan | Chain/pipeline steps, sequential processing |
 | `custom` | Gray | Anything else |
 
-## What You See
-
-### Trace List
-
-All agent runs at a glance. Status indicators (running/completed/failed), duration, token count, and tags. Traces with issues are flagged with an amber warning badge.
-
-![Trace List](public/trace_list.png)
-
-### Waterfall Timeline
-
-Every span visualized as a proportional bar showing when it started and how long it took relative to the total trace. Sequential steps cascade down like a waterfall. Issue spans are highlighted in amber.
-
-![Waterfall Timeline](public/trace_detail.png)
-
-### Span Inspector
-
-Click any span to open the slide-in panel showing:
-
-- **Status and duration**
-- **Model and provider** (for LLM spans)
-- **Token counts** (input/output)
-- **Source location** — file:line automatically captured from the call stack
-- **Input/Output** — formatted JSON
-- **Tool arguments and results**
-- **Errors**
-
-![Span Inspector](public/execution_detail.png)
+---
 
 ## Architecture
 
 ```
 pathlight/
-├── packages/
-│   ├── collector/    # Hono-based API (port 4100)
-│   │   └── src/
-│   │       ├── routes/    # REST endpoints for traces, spans, events
-│   │       └── router.ts  # CORS, health check, route mounting
-│   ├── db/           # Drizzle ORM + SQLite
-│   │   └── src/
-│   │       └── schema.ts  # traces, spans, events, projects, scores
-│   └── sdk/          # TypeScript SDK
+├── apps/
+│   └── web/              # Next.js 15 dashboard (port 3100)
 │       └── src/
-│           └── index.ts   # Pathlight, Trace, Span classes
-└── apps/
-    └── web/          # Next.js + Tailwind dashboard (port 3100)
-        └── src/app/
-            ├── page.tsx           # Trace list
-            └── traces/[id]/       # Trace detail + timeline
+│           ├── app/
+│           │   ├── page.tsx                # Trace list + real-time stream
+│           │   ├── traces/[id]/page.tsx    # Trace detail, waterfall, inspector
+│           │   ├── traces/compare/page.tsx # Side-by-side trace diff
+│           │   └── commits/page.tsx        # Per-commit regression view
+│           ├── components/
+│           │   ├── TopNav.tsx              # Sticky horizontal nav
+│           │   └── BreakpointsPanel.tsx    # Floating badge + slide-out editor
+│           └── lib/
+│               ├── api.ts                  # Collector fetch helpers
+│               ├── diff.ts                 # LCS line-diff utility
+│               └── format.ts               # Duration / token / timestamp formatters
+├── packages/
+│   ├── collector/        # Hono-based trace collector (port 4100)
+│   │   └── src/
+│   │       ├── routes/
+│   │       │   ├── traces.ts        # CRUD + SSE stream + /commits aggregate
+│   │       │   ├── spans.ts         # Span CRUD
+│   │       │   ├── projects.ts      # Project CRUD
+│   │       │   ├── breakpoints.ts   # Live breakpoint register/wait/resume/SSE
+│   │       │   └── replay.ts        # LLM replay proxy (OpenAI + Anthropic)
+│   │       ├── events.ts            # Trace EventEmitter for SSE fan-out
+│   │       ├── breakpoints.ts       # In-memory breakpoint registry
+│   │       └── router.ts            # CORS + route mounting
+│   ├── db/               # Drizzle ORM + SQLite
+│   │   ├── drizzle/                 # Migrations
+│   │   └── src/
+│   │       ├── schema.ts            # traces, spans, events, projects, scores
+│   │       ├── retire.ts            # db:retire command
+│   │       └── index.ts
+│   ├── sdk/              # TypeScript SDK
+│   │   └── src/index.ts             # Pathlight, Trace, Span, breakpoint()
+│   ├── eval/             # Assertion DSL + pathlight-eval CLI
+│   │   ├── bin/pathlight-eval.js
+│   │   ├── examples/
+│   │   └── src/index.ts             # expect() matchers, evaluate()
+│   └── cli/              # pathlight CLI (subcommand router)
+│       ├── bin/pathlight.js
+│       └── src/
+│           ├── commands/share.ts    # pathlight share <trace-id>
+│           └── viewer-template.ts   # Self-contained HTML viewer
+└── CHANGELOG.md
 ```
 
-## Data Model
+---
+
+## Data model
 
 | Entity | Description |
-|--------|-------------|
-| **Trace** | A complete agent execution. Has status, input/output, total duration, tokens, and cost. |
-| **Span** | A single step within a trace. Supports nesting via `parentSpanId`. Types: llm, tool, retrieval, agent, chain, custom. |
-| **Event** | Point-in-time annotation within a span (logs, decisions, errors). Has severity levels. |
-| **Project** | Groups traces. Has an API key for SDK authentication. |
-| **Score** | Quality annotation on a trace or span (human or auto-generated). |
+| --- | --- |
+| **Trace** | A complete agent execution. Status, input/output, duration, tokens, cost, `git_commit`/`git_branch`/`git_dirty`, `reviewed_at`. |
+| **Span** | A single step within a trace. Types: llm, tool, retrieval, agent, chain, custom. Nests via `parent_span_id`. |
+| **Event** | Point-in-time annotation within a span (logs, decisions, errors). Severity levels. |
+| **Project** | Groups traces; has an API key for SDK auth. |
+| **Score** | Quality annotation on a trace or span (human or auto). |
 
-## API Endpoints
+---
+
+## API reference
+
+### Traces
 
 | Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/v1/traces` | GET | List traces with filters (status, name, projectId) |
-| `/v1/traces` | POST | Create a new trace |
-| `/v1/traces/:id` | GET | Get trace with all spans, events, and scores |
-| `/v1/traces/:id` | PATCH | Update trace (status, output, duration) |
-| `/v1/traces/:id` | DELETE | Delete trace and all related data |
+| --- | --- | --- |
+| `/v1/traces` | GET | List traces; filter by `status`, `name`, `projectId`; paginate with `limit`, `offset` |
+| `/v1/traces` | POST | Create a trace. Accepts `gitCommit`, `gitBranch`, `gitDirty` |
+| `/v1/traces/stream` | GET | SSE stream of `trace.created` / `trace.updated` / `ping` |
+| `/v1/traces/commits` | GET | Per-commit aggregate stats (see [git-regressions docs](docs/git-regressions.md)) |
+| `/v1/traces/:id` | GET | Get trace with all spans, events, scores |
+| `/v1/traces/:id` | PATCH | Update (status, output, duration, `reviewedAt`) |
+| `/v1/traces/:id` | DELETE | Delete trace and all related rows |
+
+### Spans
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
 | `/v1/spans` | POST | Create a span |
-| `/v1/spans/:id` | PATCH | Update span (status, output, tokens, cost) |
-| `/v1/spans/:id/events` | POST | Log an event within a span |
+| `/v1/spans/:id` | PATCH | Update (status, output, tokens, cost, toolResult) |
+| `/v1/spans/:id/events` | POST | Log an event |
+
+### Breakpoints
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/v1/breakpoints` | POST | Register + block until resumed or timed out (default 15m). Returns `{ state }` |
+| `/v1/breakpoints` | GET | List active breakpoints |
+| `/v1/breakpoints/:id/resume` | POST | Resume with optional `{ state }` override |
+| `/v1/breakpoints/:id/cancel` | POST | Reject the waiting SDK call with 408 |
+| `/v1/breakpoints/stream` | GET | SSE: `snapshot`, `added`, `resolved`, `cancelled`, `ping` |
+
+### Replay
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/v1/replay/llm` | POST | Proxy LLM call. Body: `{ provider, model, messages, system?, apiKey?, baseUrl?, temperature?, maxTokens? }` |
+
+### Projects
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
 | `/v1/projects` | GET | List projects |
 | `/v1/projects` | POST | Create a project (returns API key) |
-| `/health` | GET | Health check |
 
-## SDK Reference
+### Health
 
-### `Pathlight`
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/health` | GET | Liveness probe |
+
+---
+
+## SDK reference
+
+### `new Pathlight(config)`
 
 ```typescript
 const tl = new Pathlight({
-  baseUrl: "http://localhost:4100",  // Collector URL
-  projectId: "my-project",           // Optional project grouping
-  apiKey: "tl_...",                   // Optional authentication
+  baseUrl: "http://localhost:4100",
+  projectId: "my-project",        // optional
+  apiKey: "tl_…",                  // optional
+  disableGitContext: false,        // opt out of auto git capture
 });
 ```
 
-### `Trace`
+### `tl.trace(name, input?, options?)`
 
 ```typescript
 const trace = tl.trace("agent-name", inputData, {
@@ -188,22 +304,20 @@ const trace = tl.trace("agent-name", inputData, {
   metadata: { userId: "123" },
 });
 
-// ... run your agent ...
-
 await trace.end({ output: result });
 // or
-await trace.end({ status: "failed", error: "Something went wrong" });
+await trace.end({ status: "failed", error: "…" });
 ```
 
-### `Span`
+### `trace.span(name, type, options?)`
 
 ```typescript
 const span = trace.span("step-name", "llm", {
   model: "gpt-4o",
   provider: "openai",
-  input: { prompt: "..." },
-  toolName: "search",        // for tool spans
-  toolArgs: { query: "..." }, // for tool spans
+  input: { prompt: "…" },
+  toolName: "search",          // for tool spans
+  toolArgs: { query: "…" },    // for tool spans
 });
 
 await span.end({
@@ -211,31 +325,110 @@ await span.end({
   inputTokens: 100,
   outputTokens: 200,
   cost: 0.003,
-  toolResult: { ... },       // for tool spans
+  toolResult: { …: … },        // for tool spans
 });
 
-// Log events during execution
 await span.event("decision", { choice: "retry" }, "info");
 ```
 
-Source location (file, line, function) is captured automatically when a span is created.
+Source location (file, line, function) is captured automatically.
 
-## Environment Variables
+### `tl.breakpoint(options)`
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DATABASE_URL` | `file:pathlight.db` | SQLite or Turso connection URL |
-| `DATABASE_AUTH_TOKEN` | — | Turso auth token (if using Turso) |
+```typescript
+const state = await tl.breakpoint({
+  label: "post-retrieval",
+  state: { docs, query },
+  timeoutMs: 15 * 60_000,   // default: 15 minutes
+});
+// If the dashboard edited `state`, the returned value reflects the edit.
+```
+
+See [docs/breakpoints.md](docs/breakpoints.md).
+
+---
+
+## Automatic source mapping
+
+The SDK walks the stack on every `trace.span(...)` call and captures the
+first frame outside `@pathlight/sdk` and `node_modules`. The file, line,
+column, and function name get stored in `span.metadata._source` and render
+as a clickable breadcrumb in the dashboard.
+
+This means zero instrumentation config — the waterfall always knows exactly
+where in your code each step was created.
+
+---
+
+## Issue detection
+
+The collector enriches every trace list response with per-row issue flags:
+
+- **Span failed** — `span.status === "failed"`
+- **Span error** — `span.error` is set
+- **Suspicious output** — regex matches `\bfail\b`, `failed`, `error`,
+  `exception`, `timeout`, `invalid`, `denied`, `refused`, `rejected`,
+  `incomplete`, `truncat`
+
+Traces with any issue get an amber **Issues detected** badge on the list and
+individual amber-highlighted rows in the waterfall.
+
+---
+
+## Environment variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `DATABASE_URL` | `file:pathlight.db` | SQLite or Turso URL |
+| `DATABASE_AUTH_TOKEN` | — | Turso auth token |
 | `PORT` | `4100` | Collector port |
-| `DASHBOARD_URL` | `http://localhost:3100` | Dashboard URL (for CORS) |
-| `NEXT_PUBLIC_COLLECTOR_URL` | `http://localhost:4100` | Collector URL (browser-side) |
+| `NEXT_PUBLIC_COLLECTOR_URL` | `http://localhost:4100` | Collector URL (browser) |
+| `PATHLIGHT_URL` | `http://localhost:4100` | Collector URL for CLI (`pathlight`, `pathlight-eval`) |
+| `OPENAI_API_KEY` | — | Server-side fallback for `/v1/replay/llm` |
+| `ANTHROPIC_API_KEY` | — | Server-side fallback for `/v1/replay/llm` |
 
-## Tech Stack
+---
 
-- **Collector**: [Hono](https://hono.dev) (lightweight, fast)
-- **Dashboard**: [Next.js](https://nextjs.org) + [Tailwind CSS](https://tailwindcss.com)
-- **Database**: SQLite via [Drizzle ORM](https://orm.drizzle.team)
-- **Monorepo**: [Turborepo](https://turbo.build)
+## Commands
+
+```bash
+# Workspace-level
+npx turbo dev                          # Collector + web together
+npx turbo build                        # Build all packages
+npm run dev -w packages/collector      # Collector only (4100)
+npm run dev -w apps/web                # Web only (3100)
+
+# Database
+npm run db:generate -w packages/db                 # Generate Drizzle migration
+DATABASE_URL="file:$(pwd)/packages/collector/pathlight.db" \
+  npm run db:migrate -w packages/db               # Apply migrations
+npm run db:studio -w packages/db                   # Open Drizzle Studio
+npm run db:retire -w packages/db -- ../collector/pathlight.db  # Archive
+npm run db:retire -w packages/db -- --delete ../collector/pathlight.db  # Delete
+
+# CLIs (after install)
+pathlight share <trace-id> --out report.html
+pathlight-eval specs/my-checks.mjs --base-url http://localhost:4100
+```
+
+---
+
+## Tech stack
+
+- **Collector**: [Hono](https://hono.dev) — lightweight, fast
+- **Dashboard**: [Next.js 15](https://nextjs.org) + [Tailwind CSS](https://tailwindcss.com)
+- **Database**: SQLite via [Drizzle ORM](https://orm.drizzle.team) (libSQL-compatible; Turso-ready)
+- **Monorepo**: [Turborepo](https://turbo.build) + npm workspaces
+- **Streaming**: Server-sent events (native `EventSource` + `hono/streaming`)
+
+---
+
+## Self-hosted philosophy
+
+Everything runs locally by default. SQLite file, single collector process,
+no external services required. API keys (for replay) read from env vars or
+stay in the browser's `localStorage` — never sent to any third-party beyond
+the LLM provider itself.
 
 ## License
 

--- a/apps/web/src/components/TopNav.tsx
+++ b/apps/web/src/components/TopNav.tsx
@@ -13,11 +13,12 @@ export function TopNav() {
 
   return (
     <header className="sticky top-0 z-40 bg-zinc-950/90 backdrop-blur border-b border-zinc-800">
-      <div className="max-w-7xl mx-auto px-6 h-12 flex items-center gap-6">
+      <div className="max-w-7xl mx-auto px-6 h-12 flex items-center gap-4">
         <Link href="/" className="text-base font-bold tracking-tight shrink-0">
           <span className="text-blue-400">Path</span>light
         </Link>
-        <nav className="flex items-center gap-1">
+        <span className="text-[10px] text-zinc-600 shrink-0">v0.1.0</span>
+        <nav className="ml-auto flex items-center gap-1">
           {LINKS.map((l) => {
             const active = l.match(pathname);
             return (
@@ -35,7 +36,6 @@ export function TopNav() {
             );
           })}
         </nav>
-        <span className="ml-auto text-[10px] text-zinc-600 shrink-0">v0.1.0</span>
       </div>
     </header>
   );

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# Pathlight docs
+
+Deep-dive guides for each feature. For the project overview and quick
+start, see [../README.md](../README.md).
+
+## By feature
+
+- [Real-time dashboard](realtime.md) — SSE stream, unreviewed highlighting
+- [Trace diff](trace-diff.md) — side-by-side comparison, LCS span alignment
+- [Git-linked regressions](git-regressions.md) — `/commits` page, auto-
+  captured commit SHA, regression flagging
+- [Live breakpoints](breakpoints.md) — pause agents, edit state, resume
+- [LLM replay](replay.md) — in-dashboard prompt playground against real
+  providers
+- [Eval-as-code + CI](eval.md) — pytest-style assertions over recent
+  traces, `pathlight-eval` runner
+- [Sharing traces](share.md) — single-file HTML snapshots via
+  `pathlight share`
+
+## By package
+
+- [`@pathlight/sdk`](../packages/sdk) — TypeScript SDK
+- [`@pathlight/eval`](../packages/eval) — assertion DSL + CI runner
+- [`@pathlight/cli`](../packages/cli) — command-line utilities
+- [Collector](../packages/collector) — Hono API server
+- [DB](../packages/db) — Drizzle schema + migrations
+- [Web dashboard](../apps/web) — Next.js UI
+
+## Reference
+
+- [CHANGELOG.md](../CHANGELOG.md) — chronological feature log
+- [../README.md](../README.md) — overview, quick start, API + SDK reference

--- a/docs/breakpoints.md
+++ b/docs/breakpoints.md
@@ -1,0 +1,124 @@
+# Live breakpoints
+
+`await tl.breakpoint(...)` pauses your agent mid-run until the dashboard
+resumes it — optionally with edited state. It's `pdb` for agents.
+
+## Minimal example
+
+```typescript
+import { Pathlight } from "@pathlight/sdk";
+
+const tl = new Pathlight({ baseUrl: "http://localhost:4100" });
+
+async function answer(query: string) {
+  const docs = await retrieve(query);
+
+  // Pause here; open the dashboard, inspect the state, maybe edit it.
+  const { query: q, docs: d } = await tl.breakpoint({
+    label: "post-retrieval",
+    state: { query, docs },
+  });
+
+  return summarize(d, q);
+}
+```
+
+Run the agent. When execution hits the breakpoint:
+
+1. A floating amber pulse badge appears on the dashboard.
+2. Click it to open the breakpoints panel.
+3. Edit the JSON state (or leave as-is).
+4. Click **Resume with edits** — your agent continues, with `q` / `d`
+   reflecting any edits you made.
+
+## SDK API
+
+```typescript
+tl.breakpoint<T>(options: {
+  label: string;
+  state?: T;
+  traceId?: string;
+  spanId?: string;
+  timeoutMs?: number;
+}): Promise<T>
+```
+
+- `label` (required) — shown in the dashboard list.
+- `state` — anything JSON-serializable; the editor operates on this.
+- `traceId` / `spanId` — optional back-references shown as clickable links
+  in the panel.
+- `timeoutMs` — default **15 minutes**. On timeout, the SDK returns the
+  original `state` unmodified so the agent doesn't hang forever.
+
+## Collector endpoints
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /v1/breakpoints` | Register + long-poll. Responds when the breakpoint is resumed or cancelled |
+| `GET /v1/breakpoints` | List currently-paused breakpoints |
+| `POST /v1/breakpoints/:id/resume` | Resume with `{ state }` body |
+| `POST /v1/breakpoints/:id/cancel` | Reject the SDK's waiting call with a 408 |
+| `GET /v1/breakpoints/stream` | SSE: `snapshot`, `added`, `resolved`, `cancelled`, `ping` |
+
+## Implementation notes
+
+### In-memory registry
+
+Breakpoints live in a `Map<id, Record>` on the collector with an
+`EventEmitter` backbone (`packages/collector/src/breakpoints.ts`). No DB
+persistence — breakpoints die with the process, which is the right
+lifetime. A breakpoint the SDK is waiting on across a collector restart is
+safely timed out.
+
+### Long-polling, not websockets
+
+`POST /v1/breakpoints` doesn't return until either `resume`, `cancel`, or
+timeout. This keeps the SDK as one HTTP round-trip and avoids the complexity
+of websockets / SSE in user code. The internal Promise resolver is stashed
+on the in-memory record so `resume` can find and call it.
+
+### Dashboard stream
+
+The dashboard opens an SSE stream to `/v1/breakpoints/stream` in a persistent
+layout component (`BreakpointsPanel.tsx`). On connect it gets a `snapshot`
+with all active breakpoints, then `added` / `resolved` / `cancelled` events
+keep the UI in sync across all open browser tabs.
+
+## Patterns
+
+### Conditional breakpoint
+
+```typescript
+if (totalCost > 0.50) {
+  state = await tl.breakpoint({
+    label: `expensive run: $${totalCost.toFixed(2)}`,
+    state,
+  });
+}
+```
+
+### Skip to the last hop
+
+```typescript
+for (const step of plan) {
+  await executeStep(step);
+}
+state = await tl.breakpoint({ label: "final-step", state });
+await produceAnswer(state);
+```
+
+### Breakpoint guard around a deploy
+
+Set `timeoutMs: 1000` so breakpoints auto-resume fast in prod, but use a
+developer-time wrapper that raises the timeout during debugging sessions.
+
+## Gotchas
+
+- **Production use**: don't leave `tl.breakpoint()` calls in production code.
+  They'll block for 15 minutes waiting for a dashboard that probably isn't
+  connected. Use feature flags or dev-only guards.
+- **JSON state**: whatever you pass must be JSON-serializable. Class
+  instances, functions, and circular refs will lose fidelity on the round-
+  trip.
+- **Concurrent breakpoints**: multiple agents can pause at once and all
+  appear in the dashboard panel — each is resolved independently.

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -1,0 +1,108 @@
+# Eval-as-code + CI
+
+See [packages/eval/README.md](../packages/eval/README.md) for the full
+`@pathlight/eval` reference.
+
+## TL;DR
+
+```bash
+npm install --save-dev @pathlight/eval
+```
+
+```js
+// specs/estimate.mjs
+import { expect, evaluate } from "@pathlight/eval";
+
+export default () => evaluate(
+  { baseUrl: "http://localhost:4100", name: "estimate", limit: 20 },
+  (t) => {
+    expect(t).toSucceed();
+    expect(t).toCompleteWithin("10s");
+    expect(t).toCostLessThan(0.05);
+    expect(t).toHaveNoToolLoops();
+  },
+);
+```
+
+```bash
+npx pathlight-eval specs/estimate.mjs
+```
+
+Exit `0` on all-pass; `1` with a per-trace failure list on any miss; `2`
+on spec-loading errors. Drop-in ready for GitHub Actions.
+
+## The case for eval-as-code
+
+Traditional unit tests run synthetic inputs. Pathlight evals run over
+**real recent traces** — production (or staging) runs your agent actually
+performed. When the traces already exist, the harness cost is zero and the
+signal is orders of magnitude better than synthetic replay.
+
+Combined with git-linked traces, a CI job running eval against traces from
+the last 24h tells you exactly which merge regressed what.
+
+## GitHub Actions example
+
+```yaml
+name: Agent regression check
+on:
+  schedule:
+    - cron: "0 */6 * * *"   # every 6 hours
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: "22" }
+      - run: npm ci
+      - run: npx pathlight-eval specs/estimate.mjs \
+          --base-url ${{ secrets.PATHLIGHT_URL }}
+```
+
+Pair with a nightly or on-merge cron. Failures page the on-call via your
+existing GitHub alert pipeline; no new infrastructure.
+
+## Matchers
+
+| Matcher | Fails when |
+| --- | --- |
+| `toSucceed()` | trace status ≠ `completed` |
+| `toFail()` | trace status ≠ `failed` |
+| `toCompleteWithin(d)` | total duration > `d` (ms number or `"5s"` / `"2m"` string) |
+| `toCostLessThan(usd)` | total cost ≥ `usd` |
+| `toUseAtMostTokens(n)` | total tokens > `n` |
+| `toHaveNoFailedSpans()` | any span status = `failed` |
+| `toHaveNoToolLoops(n=3)` | same tool called `n` or more times consecutively |
+| `toCallTool(name).atMost(n)` | tool called > `n` times |
+| `toCallTool(name).atLeast(n)` | tool called < `n` times |
+| `toCallTool(name).exactly(n)` | tool called ≠ `n` times |
+| `toMatchOutput(re \| str)` | trace output doesn't match |
+
+All matchers throw `AssertionError` with a human-readable message and the
+failing trace ID; the runner aggregates these into a summary.
+
+## Scoping traces
+
+The `evaluate(options, ...)` first argument decides which traces get
+checked:
+
+```typescript
+evaluate({
+  baseUrl: "http://localhost:4100",
+  name: "estimate",        // trace name filter
+  status: "completed",     // status filter
+  projectId: "proj_…",     // project filter
+  limit: 20,               // max to check (default 20)
+  gitCommit: "abc1234",    // prefix match against git_commit
+  traceIds: ["id1", "id2"] // overrides all list filters
+}, (t) => { /* … */ })
+```
+
+## See also
+
+- [packages/eval/README.md](../packages/eval/README.md) — full reference
+- [docs/git-regressions.md](git-regressions.md) — pair with commit-scoped
+  assertions for merge-gate coverage

--- a/docs/git-regressions.md
+++ b/docs/git-regressions.md
@@ -1,0 +1,123 @@
+# Git-linked regressions
+
+Every trace records the commit SHA, branch, and dirty flag of the checkout
+that produced it. The `/commits` dashboard groups traces by commit and
+highlights regressions against the previous commit.
+
+## What gets captured
+
+The SDK runs three `git` subprocesses on first trace creation per process
+(cached thereafter):
+
+- `git rev-parse HEAD` → `gitCommit`
+- `git rev-parse --abbrev-ref HEAD` → `gitBranch`
+- `git status --porcelain` → `gitDirty` (true if the output is non-empty)
+
+If `git` isn't on PATH or the process isn't inside a checkout, all three
+fields are `null` — no errors, just no git context.
+
+### Opting out
+
+```typescript
+const tl = new Pathlight({
+  baseUrl: "http://localhost:4100",
+  disableGitContext: true,
+});
+```
+
+## Database
+
+Migration 0002 adds three columns to `traces`:
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `git_commit` | text | Full SHA |
+| `git_branch` | text | Short ref name |
+| `git_dirty` | integer (boolean) | Uncommitted changes at run time |
+
+Re-run migrations after upgrading:
+
+```bash
+DATABASE_URL="file:$(pwd)/packages/collector/pathlight.db" \
+  npm run db:migrate -w packages/db
+```
+
+## Dashboard
+
+### Commit badge
+
+Every trace row in the list shows a commit pill with short SHA and branch.
+Dirty commits get an amber tint. Hover shows the full SHA.
+
+### `/?commit=<sha>` filter
+
+Clicking a commit row on `/commits` (or typing the query param yourself)
+filters the trace list to only runs from that commit. A removable chip
+appears next to the search box.
+
+### `/commits` page
+
+`GET /v1/traces/commits` returns rows grouped by `(git_commit, git_branch,
+git_dirty)` with aggregate stats:
+
+```json
+{
+  "commits": [
+    {
+      "commit": "9ec59ba...",
+      "branch": "master",
+      "dirty": false,
+      "traceCount": 12,
+      "avgDuration": 3450.2,
+      "avgTokens": 860.5,
+      "avgCost": 0.0032,
+      "failed": 0,
+      "firstSeen": 1745112340000,
+      "lastSeen": 1745114210000
+    }
+  ]
+}
+```
+
+The UI orders rows newest-first (by `lastSeen`) and computes a delta for
+each row against the next older row. Deltas are expressed as percent
+changes.
+
+### Regression highlighting
+
+A row gets a red tint if any of:
+
+- Average duration regressed by >25%
+- Average tokens regressed by >25%
+- Average cost regressed by >25%
+- `failed > 0`
+
+The 25% threshold is hard-coded in `apps/web/src/app/commits/page.tsx`
+(`REGRESSION_PCT`). Drop it lower if your pipeline is stable; raise it if
+small per-commit datasets produce noise.
+
+## Query parameters on `/v1/traces/commits`
+
+| Param | Purpose |
+| --- | --- |
+| `projectId` | Limit to one project |
+| `name` | Limit to one trace name (e.g. `estimate`) — essential when multiple agents share a project |
+| `limit` | Max rows (default 20, cap 100) |
+
+## Pairing with trace diff
+
+Seeing a red row in `/commits` answers "which commit regressed?" Clicking
+through to `/?commit=<sha>` gives you the specific runs. Then multi-select
+one of those plus a good run from the previous commit and hit **Compare**
+to see which spans got slower or more expensive.
+
+This is the main observability-driven debugging workflow Pathlight is built
+around.
+
+## Limitations
+
+- The commit is captured once per SDK process, so a long-running agent
+  process that outlives a deploy will keep attributing traces to the commit
+  it started on. Restart the process to pick up a new SHA.
+- Per-trace commit is metadata only — it doesn't actually run your code at
+  that commit. "Replay against commit X" is a future feature.

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -1,0 +1,56 @@
+# Real-time dashboard
+
+The trace list updates live — new traces and status changes appear without
+refreshing. Open a side channel by standing up an agent in one terminal and
+the dashboard in another; traces stream into the list as they're created.
+
+## How it works
+
+### Collector
+
+`GET /v1/traces/stream` opens a server-sent events (SSE) connection.
+Internally it plugs into a process-wide `EventEmitter` (`traceEvents` in
+`packages/collector/src/events.ts`). Every `POST /v1/traces` and
+`PATCH /v1/traces/:id` emits on this bus, which is then fanned out to all
+connected SSE subscribers.
+
+Events:
+
+| Event | Payload |
+| --- | --- |
+| `trace.created` | Full trace row with `issues: []` and `hasIssues` stub |
+| `trace.updated` | Full trace row (same shape) |
+| `ping` | Empty payload every 25s to keep the connection alive |
+
+The payload is intentionally the raw DB row — the dashboard layers in richer
+issue enrichment from its initial REST fetch.
+
+### Dashboard
+
+`apps/web/src/app/page.tsx` opens an `EventSource` on mount:
+
+```tsx
+const source = new EventSource(`${COLLECTOR_URL}/v1/traces/stream`);
+source.addEventListener("trace.created", …);
+source.addEventListener("trace.updated", …);
+```
+
+On `trace.created` it prepends the new row (if not already in state). On
+`trace.updated` it merges fields while preserving the richer issue data from
+the initial list fetch (SSE payloads don't re-enrich spans).
+
+## Unreviewed highlighting
+
+Every trace has a `reviewed_at` column. The list view renders a subtle
+sky-blue left-border accent on traces where `reviewedAt === null`. Opening
+a trace detail page auto-patches `reviewedAt = new Date().toISOString()` so
+the highlight disappears on the next render.
+
+This gives you a passive "inbox" — new runs stand out; anything you've
+looked at fades back into the list.
+
+## Reconnect behavior
+
+The dashboard's SSE subscribers don't handle reconnect explicitly; the
+browser's built-in `EventSource` retry is sufficient for collector restarts
+during dev. The collector sends a `ping` every 25s as a keepalive.

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -1,0 +1,129 @@
+# LLM span replay
+
+Every LLM span in the trace inspector gets an inline playground: edit the
+messages, model, or system prompt, then re-run against the real provider
+without leaving the dashboard. No more copy-pasting prompts into a separate
+playground tab.
+
+## Usage
+
+1. Open a trace. Click an LLM span in the waterfall.
+2. The right-hand inspector shows a **Replay** panel with the original
+   prompt pre-filled.
+3. Edit the system prompt, user messages, or model as desired. Add/remove
+   messages with the buttons below.
+4. Enter your provider API key — it's saved in `localStorage` per-provider
+   so you only enter it once. (If `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`
+   is set in the collector's env, the UI key is optional.)
+5. Click **Run replay**. The response renders inline with tokens and
+   duration.
+
+## How the SDK populates the editor
+
+The inspector tries to extract a `{ messages, system }` shape from
+`span.input`. If the SDK stored the span input as:
+
+```json
+{
+  "messages": [
+    { "role": "system", "content": "You are…" },
+    { "role": "user", "content": "…" }
+  ]
+}
+```
+
+…then the replay editor pre-fills the system prompt from the first message
+(if its role is `system`) and populates the message list with the rest.
+
+If the input isn't in that shape, the editor falls back to treating the
+whole input as a single user message. Works but less rich.
+
+### Tip: make your LLM spans replay-friendly
+
+Pass the raw chat payload to `span.input` rather than a post-processed
+result. You don't have to — the span itself is independent — but it makes
+the replay experience much better:
+
+```typescript
+const span = trace.span("chat", "llm", {
+  model: "gpt-4o",
+  provider: "openai",
+  input: { messages },   // the actual payload, pre-send
+});
+const res = await openai.chat.completions.create({ model: "gpt-4o", messages });
+await span.end({ output: res.choices[0].message.content, /* tokens, cost */ });
+```
+
+## Collector proxy
+
+The browser can't hit `api.openai.com` or `api.anthropic.com` directly
+(CORS), so the collector exposes a proxy:
+
+```
+POST /v1/replay/llm
+Content-Type: application/json
+
+{
+  "provider": "openai",
+  "model": "gpt-4o-mini",
+  "messages": [{ "role": "user", "content": "hi" }],
+  "system": "optional system prompt",
+  "apiKey": "sk-…",
+  "baseUrl": "https://api.openai.com",
+  "temperature": 0.7,
+  "maxTokens": 1024
+}
+```
+
+Response shape:
+
+```json
+{
+  "provider": "openai",
+  "model": "gpt-4o-mini-2024-…",
+  "output": "…",
+  "raw": { /* full provider response */ },
+  "inputTokens": 50,
+  "outputTokens": 20,
+  "durationMs": 640
+}
+```
+
+## Provider support
+
+### OpenAI-compatible
+
+Default path. Hits `POST <baseUrl>/v1/chat/completions` with a standard
+OpenAI chat payload. Works with:
+
+- OpenAI
+- Together AI (`baseUrl: "https://api.together.xyz"`)
+- Groq (`baseUrl: "https://api.groq.com/openai"`)
+- Ollama (`baseUrl: "http://localhost:11434"`, no `apiKey` needed)
+- LiteLLM proxy, Portkey, any OpenAI-compatible endpoint
+
+### Anthropic
+
+Set `provider: "anthropic"`. Hits `POST /v1/messages` with Anthropic's
+schema (including the `anthropic-version` header). The collector translates
+the response back into the unified `output` field.
+
+## API key handling
+
+Priority order:
+1. `apiKey` field in the request body (per-request override)
+2. Provider env var on the collector (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
+
+The dashboard stores the per-request key in `localStorage` under
+`pathlight:replay-key:<provider>` so you don't re-type it. It never sends
+the key anywhere except the collector → provider chain.
+
+## Not in scope yet
+
+- **Tool span replay** — tool calls depend on user code (your `search()`
+  function), and Pathlight can't re-invoke arbitrary functions safely.
+- **Multi-span replay-from-point** — re-running an entire agent from a
+  specific span requires SDK-side orchestration that's tracked as a future
+  feature.
+- **Saving the replay as a new trace** — a future enhancement; today the
+  replay is one-shot and doesn't persist.

--- a/docs/share.md
+++ b/docs/share.md
@@ -1,0 +1,48 @@
+# Sharing traces
+
+See [packages/cli/README.md](../packages/cli/README.md) for the full
+`pathlight share` reference.
+
+## TL;DR
+
+```bash
+pathlight share <trace-id> --out ./bug-report.html
+```
+
+Produces a single self-contained HTML file. Open in any browser — no
+Pathlight, no server, no dependencies. Perfect for attaching to a GitHub
+issue or Slack thread.
+
+## Redaction
+
+Sanitize inputs / outputs / errors before sharing:
+
+```bash
+pathlight share <trace-id> \
+  --redact-input \
+  --redact-output \
+  --redact-errors \
+  --out safe-for-sharing.html
+```
+
+Redacted fields are replaced with the literal string `"[redacted]"` in the
+embedded JSON; everything else (timings, span structure, metadata, git
+provenance) is preserved.
+
+## What's in the file
+
+- Summary card strip: duration, span count, tokens, cost
+- Trace input / output (formatted JSON)
+- Waterfall timeline with clickable `<details>` elements that expand to
+  show per-span input / output / error
+- Git provenance chip (commit SHA + branch) if captured
+- "Exported at" footer
+
+No network calls. No tracking. No telemetry. One file, local-first.
+
+## See also
+
+- [packages/cli/README.md](../packages/cli/README.md) — full CLI options
+- [docs/trace-diff.md](trace-diff.md) — if both you and the recipient have
+  Pathlight, prefer sending two trace IDs and letting the recipient run
+  `/traces/compare?a=…&b=…` — higher-fidelity than static HTML.

--- a/docs/trace-diff.md
+++ b/docs/trace-diff.md
@@ -1,0 +1,75 @@
+# Trace diff
+
+Side-by-side comparison of two traces. Built for the question "did my prompt
+change break anything?"
+
+## Usage
+
+1. Open the trace list.
+2. Hover any row — a checkbox appears on the left. Click to select.
+3. Select a second row. A floating **Compare →** action bar appears.
+4. Click Compare. The page routes to `/traces/compare?a=<idA>&b=<idB>`.
+
+You can also navigate directly to `/traces/compare?a=…&b=…` with any two
+trace IDs.
+
+## What you see
+
+### Trace headers (top)
+
+Side A (red badge) and side B (emerald badge). Each shows the trace name,
+status dot, short id, and key metrics (duration, tokens, span count).
+Clicking the name opens the full trace detail in a new context.
+
+### Summary delta bar
+
+Single-line summary of how B compares to A:
+
+- **Duration** — percent change
+- **Tokens** — percent change
+- **Cost** — percent change
+- **Span count** — raw count change
+
+Positive deltas show amber (worse); negative show emerald (better). Deltas
+<1% render muted since they're noise.
+
+### Trace input / output diff
+
+Pretty-printed JSON with a line-level LCS diff. Added lines are emerald,
+removed lines are red, unchanged lines muted. If A and B are byte-identical,
+the diff view collapses to a single muted preview.
+
+### Aligned spans
+
+LCS alignment on span names produces pairs:
+
+- Both sides present → row shows both span cards plus the per-pair duration delta between them
+- A only → row tinted red, B cell says "(removed in B)"
+- B only → row tinted emerald, A cell says "(added in B)"
+
+Clicking any row with both sides present expands inline to show per-span
+input and output JSON diffs.
+
+## Algorithm
+
+Span alignment uses classic Longest Common Subsequence on the list of span
+names. This gracefully handles:
+
+- Spans added/removed between versions
+- Spans reordered (best-effort — drastic reordering produces a degraded
+  alignment but never crashes)
+- Identical traces (every pair aligns; every diff shows "unchanged")
+
+Line diff for JSON bodies is the same LCS implementation applied to pretty-
+printed text. Implementation lives in `apps/web/src/lib/diff.ts` — ~50 lines,
+zero dependencies.
+
+## Limitations
+
+- LCS on names can't match a renamed span to its counterpart. If a span's
+  name changes between runs, it'll appear as one removed and one added.
+- Line-level diff isn't semantic — re-ordering keys in a JSON object will
+  show as a delete+add pair even though the values are unchanged. Good
+  enough for 95% of cases; semantic JSON diff is a future improvement.
+- No support yet for comparing more than two traces. A matrix view is
+  doable but hasn't been needed.

--- a/packages/collector/README.md
+++ b/packages/collector/README.md
@@ -1,0 +1,81 @@
+# @pathlight/collector
+
+Hono-based HTTP API that ingests traces from the SDK, persists them to
+SQLite via Drizzle, and serves the dashboard. Runs on port **4100** by
+default.
+
+## Run
+
+```bash
+# From repo root
+npm run dev -w packages/collector
+
+# Or via turbo, alongside the web dashboard
+npx turbo dev
+```
+
+## Configuration
+
+| Env var | Default | Purpose |
+| --- | --- | --- |
+| `PORT` | `4100` | HTTP port |
+| `DATABASE_URL` | `file:pathlight.db` | SQLite path or Turso URL |
+| `DATABASE_AUTH_TOKEN` | — | Turso auth token |
+| `OPENAI_API_KEY` | — | Server-side fallback for `/v1/replay/llm` |
+| `ANTHROPIC_API_KEY` | — | Server-side fallback for `/v1/replay/llm` |
+
+The collector reads `.env` from the repo root on startup (via `dotenv`).
+
+## Routes
+
+Mounted in `src/router.ts`:
+
+- `/v1/traces` — trace CRUD, SSE stream, commit aggregates
+  ([trace routes](src/routes/traces.ts))
+- `/v1/spans` — span CRUD + event logging ([span routes](src/routes/spans.ts))
+- `/v1/projects` — project CRUD ([project routes](src/routes/projects.ts))
+- `/v1/breakpoints` — live breakpoint registry + SSE
+  ([breakpoint routes](src/routes/breakpoints.ts))
+- `/v1/replay/llm` — OpenAI/Anthropic proxy ([replay routes](src/routes/replay.ts))
+- `/health` — liveness
+
+Full route and response reference in the [main README](../../README.md#api-reference).
+
+## Design notes
+
+### SSE over long-poll
+
+The trace stream uses SSE (`hono/streaming`) because the dashboard benefits
+from server-push. The breakpoint API uses long-polling on
+`POST /v1/breakpoints` (blocks until resume) because the SDK side wants a
+single HTTP round-trip with no event-loop complexity.
+
+### In-memory vs. persisted state
+
+Traces/spans/events/scores live in SQLite. Breakpoints are **in-memory
+only** — they die with the process, which is the correct lifetime. A
+breakpoint the SDK is waiting on across a collector restart will time out
+cleanly (default 15m).
+
+### CORS
+
+Currently `origin: "*"` — the collector is a dev tool meant to run on
+localhost alongside the developer's browser. Harden this before exposing
+the collector on a public network.
+
+## Files
+
+```
+src/
+├── index.ts              # Server entrypoint — dotenv, migrations, Hono serve
+├── router.ts             # CORS + route mounting
+├── events.ts             # Trace EventEmitter for SSE fan-out
+├── breakpoints.ts        # In-memory breakpoint registry
+├── middleware/           # (currently empty — reserved)
+└── routes/
+    ├── traces.ts         # List, get, create, update, delete, /stream, /commits
+    ├── spans.ts          # Span CRUD, event logging
+    ├── projects.ts       # Project CRUD
+    ├── breakpoints.ts    # Register + wait, resume, cancel, SSE stream
+    └── replay.ts         # LLM replay proxy (OpenAI-compatible + Anthropic)
+```

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -15,7 +15,11 @@
  *   trace.end({ output: finalResult });
  */
 
-import { execSync } from "node:child_process";
+// Git metadata is captured on Node.js only. In React Native / browser bundles
+// (Metro, webpack, Vite) a static `import "node:child_process"` would be
+// hoisted into the output and blow up the bundle, so the import is hidden
+// behind a runtime require that static analyzers cannot see.
+type ExecSync = (typeof import("node:child_process"))["execSync"];
 
 interface GitContext {
   commit: string;
@@ -24,11 +28,38 @@ interface GitContext {
 }
 
 let cachedGit: GitContext | null | undefined;
+let cachedExec: ExecSync | null | undefined;
+
+function loadExecSync(): ExecSync | null {
+  if (cachedExec !== undefined) return cachedExec;
+  // Bail on non-Node runtimes (RN has no `process.versions.node`).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const proc = (globalThis as any).process;
+  if (!proc || !proc.versions || !proc.versions.node) {
+    cachedExec = null;
+    return null;
+  }
+  try {
+    // Function-constructor require() is opaque to bundlers so the
+    // `node:child_process` string is never statically resolved.
+    const mod = Function("return require('node:child_process')")() as typeof import("node:child_process");
+    cachedExec = mod.execSync;
+    return cachedExec;
+  } catch {
+    cachedExec = null;
+    return null;
+  }
+}
 
 // Capture git HEAD / branch / dirtiness once per process. Returns null when the
-// process isn't inside a git checkout or when git isn't on PATH.
+// process isn't Node, isn't inside a git checkout, or git isn't on PATH.
 function detectGitContext(): GitContext | null {
   if (cachedGit !== undefined) return cachedGit;
+  const execSync = loadExecSync();
+  if (!execSync) {
+    cachedGit = null;
+    return null;
+  }
   try {
     const commit = execSync("git rev-parse HEAD", { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
     const branch = execSync("git rev-parse --abbrev-ref HEAD", { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();


### PR DESCRIPTION
## Summary
- Right-align Traces / Commits in the top nav
- Rewrite README.md around a feature tour + five workflow playbooks
- Add CHANGELOG.md with every shipped feature keyed to its issue
- Add docs/ folder with per-feature deep-dives (realtime, trace diff, git regressions, breakpoints, replay, share, eval)
- Add packages/collector/README.md (previously missing)
- Refresh CLAUDE.md to reflect current architecture
- Include a pre-existing SDK bundling fix for non-Node runtimes

## Why
Everything shipped in the last session was undocumented at the project level. README still described only the v0.1.0 feature set. This PR brings the docs surface up to parity with the code.

## Test plan
- [ ] \`npx turbo build\` — done, clean
- [ ] Load dashboard, verify nav links are right-aligned
- [ ] Skim README.md + docs/*.md for broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)