### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to Pathlight. Dates are release days, not merge days.
 
-## Unreleased
+## 0.2.0 — 2026-04-20
+
+First tagged release since 0.1.0. Adds real-time streaming, trace diff,
+git-linked regressions, live breakpoints, LLM replay, the `@pathlight/eval`
+CI runner, and the `pathlight share` CLI. New packages published to npm:
+`@pathlight/eval`, `@pathlight/cli`. Updated: `@pathlight/sdk`.
 
 ### Added — Real-time dashboard ([#3](https://github.com/syndicalt/pathlight/issues/3))
 - **SSE stream** at `GET /v1/traces/stream` broadcasts `trace.created` and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pathlight",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "packageManager": "npm@10.9.7",
   "description": "Visual debugging, execution traces, and observability for AI agents",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pathlight/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Command-line tools for Pathlight",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pathlight/eval",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Assertion DSL and CI runner for Pathlight traces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pathlight/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SDK for Pathlight — visual debugging and observability for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -21,7 +21,7 @@
 // behind a runtime require that static analyzers cannot see.
 type ExecSync = (typeof import("node:child_process"))["execSync"];
 
-interface GitContext {
+export interface GitContext {
   commit: string;
   branch: string;
   dirty: boolean;
@@ -104,6 +104,13 @@ interface PathlightConfig {
   apiKey?: string;
   /** Disable automatic git-context capture (commit/branch/dirty). */
   disableGitContext?: boolean;
+  /**
+   * Provide git context explicitly. Use this in environments where the SDK
+   * cannot shell out to `git` (React Native, browsers, sandboxed runtimes):
+   * capture the values at build time and pass them in. When set, this
+   * overrides any auto-detection.
+   */
+  git?: GitContext | null;
 }
 
 export class Pathlight {
@@ -111,12 +118,14 @@ export class Pathlight {
   private projectId?: string;
   private apiKey?: string;
   private gitContextDisabled: boolean;
+  private gitOverride: GitContext | null | undefined;
 
   constructor(config: PathlightConfig) {
     this.baseUrl = config.baseUrl.replace(/\/$/, "");
     this.projectId = config.projectId;
     this.apiKey = config.apiKey;
     this.gitContextDisabled = !!config.disableGitContext;
+    this.gitOverride = config.git;
   }
 
   private async post(path: string, body: unknown) {
@@ -191,7 +200,11 @@ export class Pathlight {
 
   /** @internal */
   async _createTrace(data: { name: string; projectId?: string; input?: unknown; tags?: string[]; metadata?: unknown }) {
-    const git = this.gitContextDisabled ? null : detectGitContext();
+    const git = this.gitContextDisabled
+      ? null
+      : this.gitOverride !== undefined
+        ? this.gitOverride
+        : detectGitContext();
     return this.post("/v1/traces", {
       ...data,
       projectId: data.projectId || this.projectId,


### PR DESCRIPTION
Version bump for @pathlight/sdk, @pathlight/eval, @pathlight/cli. See CHANGELOG.md for what's in this release.