### PR TITLE
chore: switch PyPI publish to token auth

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
     defaults:
       run:
         working-directory: packages/sdk-python
@@ -32,3 +29,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/sdk-python/dist
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
OIDC trusted publisher requires PyPI-side config before the first publish; use token auth for the first release, swap back to OIDC later.