### PR TITLE
chore: use twine directly for PyPI publish

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -20,13 +20,16 @@ jobs:
           python-version: "3.12"
 
       - name: Install build tooling
-        run: pip install build
+        run: pip install build twine
 
       - name: Build distribution
         run: python -m build
 
+      - name: Twine check
+        run: twine check dist/*
+
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: packages/sdk-python/dist
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*


### PR DESCRIPTION
The `pypa/gh-action-pypi-publish` action attempts OIDC handshake even when a password is set. Swap for plain twine with the PYPI_API_TOKEN secret.