### PR TITLE
docs: refresh for Docker + OTLP + sdk-python

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,18 +22,31 @@ Turborepo monorepo with npm workspaces:
   CI runner.
 - `packages/cli` — `@pathlight/cli` with `pathlight share` subcommand for
   exporting single-file HTML trace snapshots.
+- `packages/sdk-python` — `pathlight` on PyPI. Sync + async clients,
+  context managers, full feature parity with the TS SDK.
 - `apps/web` — Next.js + Tailwind dashboard (port 3100). Routes: `/`
   (list), `/traces/[id]` (detail + side-by-side inspector), `/traces/compare`
   (diff), `/commits` (regression view).
+- Root-level `Dockerfile.collector` + `Dockerfile.web` + `docker-compose.yml`
+  ship the stack. GHCR publishes `ghcr.io/syndicalt/pathlight-{collector,web}`
+  on every push to master.
 
 ## Commands
 
 ```bash
-npx turbo dev               # Start collector + web concurrently
-npm run dev -w packages/collector   # Collector only (port 4100)
-npm run dev -w apps/web             # Web UI only (port 3100)
+# Docker (single-command self-host)
+docker compose up -d               # Pull + run both services
+docker compose down -v             # Stop + wipe data
 
-# Database (the collector's DB is at packages/collector/pathlight.db)
+# Local dev
+npx turbo dev                      # Start collector + web concurrently
+npx turbo build                    # Build all packages
+npx turbo test                     # Run the test suite
+npm run dev -w packages/collector  # Collector only (port 4100)
+npm run dev -w apps/web            # Web UI only (port 3100)
+
+# Database (the collector's DB is at packages/collector/pathlight.db
+# in local dev; in Docker it lives in the pathlight_data volume)
 npm run db:generate -w packages/db
 DATABASE_URL="file:$(pwd)/packages/collector/pathlight.db" \
   npm run db:migrate -w packages/db
@@ -91,4 +104,11 @@ const state = await tl.breakpoint({ label: "checkpoint", state: { foo } });
 - Commit messages use `feat(#N):` / `fix(#N):` / `refactor(web):` style.
 - Shiplog workflow: each feature gets an `issue/N-slug` branch and PR.
 - Keep the collector DB migrated (`DATABASE_URL` must point at
-  `packages/collector/pathlight.db` for CLI migrations).
+  `packages/collector/pathlight.db` for CLI migrations). Docker handles
+  this automatically on container boot.
+- Workspace packages `@pathlight/db`, `@pathlight/sdk`, `@pathlight/eval`,
+  `@pathlight/cli` all compile to `dist/` via `tsc`. **Don't** switch any
+  of them back to `main: ./src/*.ts` — it breaks production `node`
+  execution (only works under `tsx`).
+- Empty directories aren't tracked by git. If a new empty dir needs to
+  exist for Docker COPY to work, add a `.gitkeep` (see `apps/web/public/`).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ No more debugging agents with `console.log`.
 | **`pathlight share`** | Single-file HTML snapshot of a trace, zero deps to open | [packages/cli/README.md](packages/cli/README.md) |
 | **OpenTelemetry interop** | Collector accepts OTLP/HTTP; any OTel-instrumented app can ship to Pathlight | [docs/opentelemetry.md](docs/opentelemetry.md) |
 | **Python SDK** | `pip install pathlight` — same dashboard features, Pythonic API, sync + async | [docs/python.md](docs/python.md) |
+| **One-command deploy** | `docker compose up -d` pulls prebuilt images from GHCR; SQLite persists in a named volume | [docs/docker.md](docs/docker.md) |
 | **Automatic source mapping** | Every span records the file:line where it was created | [overview](#automatic-source-mapping) |
 | **Issue detection** | Failed spans + error-pattern matches flag traces in the list | [overview](#issue-detection) |
 
@@ -211,18 +212,25 @@ pathlight/
 │   │       │   ├── spans.ts         # Span CRUD
 │   │       │   ├── projects.ts      # Project CRUD
 │   │       │   ├── breakpoints.ts   # Live breakpoint register/wait/resume/SSE
-│   │       │   └── replay.ts        # LLM replay proxy (OpenAI + Anthropic)
+│   │       │   ├── replay.ts        # LLM replay proxy (OpenAI + Anthropic)
+│   │       │   └── otlp.ts          # OTLP/HTTP ingest (gen_ai.* mapping)
 │   │       ├── events.ts            # Trace EventEmitter for SSE fan-out
 │   │       ├── breakpoints.ts       # In-memory breakpoint registry
 │   │       └── router.ts            # CORS + route mounting
-│   ├── db/               # Drizzle ORM + SQLite
-│   │   ├── drizzle/                 # Migrations
+│   ├── db/               # Drizzle ORM + SQLite (builds to dist/)
+│   │   ├── drizzle/                 # Migrations (shipped with runtime)
 │   │   └── src/
 │   │       ├── schema.ts            # traces, spans, events, projects, scores
 │   │       ├── retire.ts            # db:retire command
 │   │       └── index.ts
-│   ├── sdk/              # TypeScript SDK
+│   ├── sdk/              # TypeScript SDK — @pathlight/sdk
 │   │   └── src/index.ts             # Pathlight, Trace, Span, breakpoint()
+│   ├── sdk-python/       # Python SDK — pathlight on PyPI
+│   │   ├── src/pathlight/
+│   │   │   ├── client.py            # Pathlight / AsyncPathlight classes
+│   │   │   ├── git.py               # Auto git-context capture
+│   │   │   └── _source.py           # Stack-walk source location
+│   │   └── tests/                   # pytest + pytest-httpx
 │   ├── eval/             # Assertion DSL + pathlight-eval CLI
 │   │   ├── bin/pathlight-eval.js
 │   │   ├── examples/
@@ -232,6 +240,14 @@ pathlight/
 │       └── src/
 │           ├── commands/share.ts    # pathlight share <trace-id>
 │           └── viewer-template.ts   # Self-contained HTML viewer
+├── Dockerfile.collector  # Multi-stage build; migrations run on boot
+├── Dockerfile.web        # Next.js 15 standalone runtime
+├── docker-compose.yml    # Collector + dashboard + SQLite volume
+├── .github/workflows/
+│   ├── ci.yml            # Node + Python tests on every PR
+│   ├── docker.yml        # Publish GHCR images on push to master
+│   ├── publish-python.yml  # PyPI release on py-v* tag
+│   └── ...
 └── CHANGELOG.md
 ```
 
@@ -417,13 +433,20 @@ individual amber-highlighted rows in the waterfall.
 ## Commands
 
 ```bash
-# Workspace-level
+# Docker (recommended)
+docker compose up -d                   # Pull + start everything
+docker compose down                    # Stop (data preserved in volume)
+docker compose down -v                 # Stop + wipe data
+docker compose pull && docker compose up -d   # Upgrade to latest images
+
+# Local dev (monorepo)
 npx turbo dev                          # Collector + web together
 npx turbo build                        # Build all packages
+npx turbo test                         # Run the full test suite
 npm run dev -w packages/collector      # Collector only (4100)
 npm run dev -w apps/web                # Web only (3100)
 
-# Database
+# Database (local dev — Docker handles migrations automatically)
 npm run db:generate -w packages/db                 # Generate Drizzle migration
 DATABASE_URL="file:$(pwd)/packages/collector/pathlight.db" \
   npm run db:migrate -w packages/db               # Apply migrations

--- a/packages/collector/README.md
+++ b/packages/collector/README.md
@@ -37,6 +37,8 @@ Mounted in `src/router.ts`:
 - `/v1/breakpoints` — live breakpoint registry + SSE
   ([breakpoint routes](src/routes/breakpoints.ts))
 - `/v1/replay/llm` — OpenAI/Anthropic proxy ([replay routes](src/routes/replay.ts))
+- `/v1/otlp/traces` — OTLP/HTTP ingest for OTel-instrumented apps
+  ([otlp routes](src/routes/otlp.ts))
 - `/health` — liveness
 
 Full route and response reference in the [main README](../../README.md#api-reference).
@@ -77,5 +79,6 @@ src/
     ├── spans.ts          # Span CRUD, event logging
     ├── projects.ts       # Project CRUD
     ├── breakpoints.ts    # Register + wait, resume, cancel, SSE stream
-    └── replay.ts         # LLM replay proxy (OpenAI-compatible + Anthropic)
+    ├── replay.ts         # LLM replay proxy (OpenAI-compatible + Anthropic)
+    └── otlp.ts           # OTLP/HTTP ingest (gen_ai.* semantic conventions)
 ```


### PR DESCRIPTION
Post-Docker doc sweep — architecture tree now includes sdk-python and Dockerfiles, commands block has docker compose, OTLP route surfaced in collector README.