### PR TITLE
feat: GitHub Pages landing site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+name: Deploy landing page
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "site/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,55 @@
+# Pathlight landing page
+
+Zero-build static site for <https://syndicalt.github.io/pathlight/>.
+
+## Structure
+
+```
+site/
+├── index.html      # Single-page landing
+├── style.css       # All styles; dark theme, type-forward
+├── README.md       # This file
+└── assets/         # Screenshots + social preview image
+    ├── og-cover.png        # 1200x630 social preview
+    ├── replay.png          # Replay editor feature shot
+    ├── breakpoint.png      # Breakpoint panel feature shot
+    └── diff.png            # Trace compare feature shot
+```
+
+## Screenshots to capture
+
+Each `<img>` in `index.html` has a matching `<!-- SCREENSHOT: name — … -->`
+comment directly above it with the expected filename and a one-line
+shot description. Drop the PNGs into `assets/` with the names below and
+GitHub Pages will redeploy on push.
+
+| File | What to capture |
+| --- | --- |
+| `assets/og-cover.png` | Social preview (1200×630). Dashboard with trace list + open waterfall, dark theme, a few span bars visible. |
+| `assets/replay.png` | Trace detail with an LLM span selected, replay editor open showing editable system prompt + message + API key input + "Run replay" button. Bonus: a result panel populated underneath. |
+| `assets/breakpoint.png` | Dashboard with the floating amber "N paused" badge and the breakpoint editor panel visible, JSON state in the textarea, Resume buttons at the bottom. |
+| `assets/diff.png` | Trace compare view with two trace headers at top, the red-highlighted delta bar in the middle, and aligned spans rows with at least one expanded showing the line-level JSON diff. |
+
+Dimensions don't have to be exact — the CSS fits whatever aspect ratio
+you give it. Aim for retina-crisp widescreen shots (at least 1600px
+wide).
+
+## Local preview
+
+The site is pure static — no build step.
+
+```bash
+cd site
+python3 -m http.server 8000
+# → http://localhost:8000
+```
+
+## Deploy
+
+Pushes to `master` that touch `site/**` run the `Deploy landing page`
+workflow and publish via GitHub Pages. First-time setup: in repo
+Settings → Pages, set **Source** to "GitHub Actions".
+
+The OG preview URL is baked into `index.html` as
+`https://syndicalt.github.io/pathlight/`. If you move to a custom
+domain later, update that meta tag.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,268 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Pathlight — a debugger for AI agents</title>
+<meta name="description" content="Visual traces, live breakpoints, prompt replay. Self-hosted, open source observability for AI agents." />
+
+<!-- Social preview -->
+<meta property="og:title" content="Pathlight — a debugger for AI agents" />
+<meta property="og:description" content="Visual traces, live breakpoints, prompt replay. Self-hosted, open source." />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://syndicalt.github.io/pathlight/" />
+<!-- SCREENSHOT: og-cover.png (1200x630) — dashboard with trace list + waterfall visible, dark theme, a few lit-up spans -->
+<meta property="og:image" content="assets/og-cover.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:image" content="assets/og-cover.png" />
+
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='6' cy='6' r='2' fill='%2360a5fa'/%3E%3Ccircle cx='18' cy='6' r='2' fill='%23e4e4e7'/%3E%3Ccircle cx='18' cy='18' r='2' fill='%23e4e4e7'/%3E%3Cpath d='M8 6h6a4 4 0 014 4v8' stroke='%23e4e4e7' stroke-width='2' stroke-linecap='round' fill='none'/%3E%3C/svg%3E" />
+
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<nav class="nav">
+  <a href="#top" class="brand">
+    <span class="brand-accent">Path</span>light
+  </a>
+  <div class="nav-links">
+    <a href="https://github.com/syndicalt/pathlight#readme">Docs</a>
+    <a href="https://github.com/syndicalt/pathlight/blob/master/CHANGELOG.md">Changelog</a>
+    <a href="https://github.com/syndicalt/pathlight" class="nav-cta">GitHub →</a>
+  </div>
+</nav>
+
+<main>
+
+<section class="hero" id="top">
+  <div class="hero-text">
+    <p class="eyebrow">Open source · self-hosted · <span class="dot"></span> live</p>
+    <h1>A debugger for <span class="highlight">AI agents</span>.</h1>
+    <p class="tagline">
+      Visual traces, live breakpoints, prompt replay. Drop the SDK in, get every
+      LLM call and tool invocation as an editable, diffable trace.
+    </p>
+    <div class="cta-row">
+      <a href="#install" class="btn btn-primary">Get started</a>
+      <a href="https://github.com/syndicalt/pathlight" class="btn btn-ghost">
+        <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        Star on GitHub
+      </a>
+    </div>
+    <div class="install-pill">
+      <code>docker compose up -d</code>
+      <button class="copy" data-copy="docker compose up -d">Copy</button>
+    </div>
+  </div>
+
+  <!-- Animated pseudo-waterfall visual. Pure CSS — no image loaded. -->
+  <aside class="hero-visual" aria-hidden="true">
+    <div class="wf-frame">
+      <div class="wf-titlebar">
+        <span class="dot-red"></span><span class="dot-amber"></span><span class="dot-green"></span>
+        <span class="wf-title">research-agent</span>
+        <span class="wf-badge">completed</span>
+      </div>
+      <div class="wf-axis"><span>0ms</span><span>8.4s</span></div>
+      <div class="wf-row">
+        <span class="wf-type t-llm">llm</span><span class="wf-name">classify-question</span>
+        <div class="wf-bar"><div class="wf-fill t-llm" style="left:0%;width:9%"></div></div>
+      </div>
+      <div class="wf-row">
+        <span class="wf-type t-llm">llm</span><span class="wf-name">generate-queries</span>
+        <div class="wf-bar"><div class="wf-fill t-llm" style="left:9%;width:11%"></div></div>
+      </div>
+      <div class="wf-row">
+        <span class="wf-type t-tool">tool</span><span class="wf-name">web_search</span>
+        <div class="wf-bar"><div class="wf-fill t-tool" style="left:20%;width:14%"></div></div>
+      </div>
+      <div class="wf-row">
+        <span class="wf-type t-retrieval">retr</span><span class="wf-name">fetch-url</span>
+        <div class="wf-bar"><div class="wf-fill t-retrieval" style="left:34%;width:8%"></div></div>
+      </div>
+      <div class="wf-row wf-highlight">
+        <span class="wf-type t-llm">llm</span><span class="wf-name">synthesize-answer</span>
+        <div class="wf-bar"><div class="wf-fill t-llm" style="left:42%;width:34%"></div></div>
+      </div>
+      <div class="wf-row">
+        <span class="wf-type t-llm">llm</span><span class="wf-name">self-check</span>
+        <div class="wf-bar"><div class="wf-fill t-llm" style="left:76%;width:10%"></div></div>
+      </div>
+      <div class="wf-row">
+        <span class="wf-type t-tool">tool</span><span class="wf-name">fact_check</span>
+        <div class="wf-bar"><div class="wf-fill t-tool" style="left:86%;width:14%"></div></div>
+      </div>
+    </div>
+  </aside>
+</section>
+
+<section class="features">
+  <div class="feature">
+    <div class="feature-text">
+      <p class="eyebrow">Prompt replay</p>
+      <h2>Change the prompt. Re-run it against the real model. Without leaving the dashboard.</h2>
+      <p>
+        Click any LLM span, edit system prompt or any message, paste your provider key
+        once. <code>Run replay</code> hits OpenAI or Anthropic directly and renders the
+        new output inline. No more copy-pasting into a separate playground tab.
+      </p>
+    </div>
+    <div class="feature-media">
+      <!-- SCREENSHOT: replay.png — trace detail page with LLM span selected, replay editor visible with system prompt + message list + API key field + "Run replay" button; ideally the result panel also populated -->
+      <img src="assets/replay.png" alt="Replay editor open on an LLM span showing editable system prompt, message, and inline response" />
+    </div>
+  </div>
+
+  <div class="feature flip">
+    <div class="feature-text">
+      <p class="eyebrow">Live breakpoints</p>
+      <h2>Pause an agent mid-run. Edit its state. Resume.</h2>
+      <p>
+        <code>await tl.breakpoint(&#123; label, state &#125;)</code> anywhere in your
+        agent. The floating badge on the dashboard lights up, you inspect and edit
+        the state as JSON, hit <em>Resume with edits</em> — the agent continues with
+        whatever you changed. It's <code>pdb</code> for agents.
+      </p>
+    </div>
+    <div class="feature-media">
+      <!-- SCREENSHOT: breakpoint.png — dashboard with floating amber "N paused" badge + open breakpoint panel with JSON state editor -->
+      <img src="assets/breakpoint.png" alt="Breakpoint panel with JSON state editor and Resume / Cancel buttons" />
+    </div>
+  </div>
+
+  <div class="feature">
+    <div class="feature-text">
+      <p class="eyebrow">Trace diff</p>
+      <h2>Did my prompt change regress anything?</h2>
+      <p>
+        Select two traces, click <em>Compare</em>. Every span aligned by name with
+        per-pair duration deltas. Input and output diffs rendered line-by-line.
+        Obvious-at-a-glance when a prompt tweak tanks latency, cost, or quality.
+      </p>
+    </div>
+    <div class="feature-media">
+      <!-- SCREENSHOT: diff.png — trace compare view showing two trace headers side by side, summary delta bar in the middle (with red percentages), aligned spans below -->
+      <img src="assets/diff.png" alt="Side-by-side trace comparison with regression deltas highlighted" />
+    </div>
+  </div>
+</section>
+
+<section class="pillars">
+  <div class="pillar">
+    <h3>Git-linked</h3>
+    <p>Every trace carries the commit SHA that produced it. The <code>/commits</code> dashboard flags cost and latency regressions above 25% in red.</p>
+  </div>
+  <div class="pillar">
+    <h3>CI-ready</h3>
+    <p><code>@pathlight/eval</code> gives you pytest-style assertions over recent traces. <code>npx pathlight-eval specs.mjs</code> exits nonzero on any violation.</p>
+  </div>
+  <div class="pillar">
+    <h3>OpenTelemetry</h3>
+    <p>Point any OTel-instrumented app at <code>/v1/otlp/traces</code> — <code>gen_ai.*</code> attributes map straight into Pathlight's span model.</p>
+  </div>
+  <div class="pillar">
+    <h3>TypeScript + Python</h3>
+    <p><code>npm install @pathlight/sdk</code> or <code>pip install pathlight</code>. Same dashboard, same features, same data model.</p>
+  </div>
+  <div class="pillar">
+    <h3>Self-hosted</h3>
+    <p>Your traces stay on your machine. Single SQLite file. Docker Compose or one <code>turbo dev</code>.</p>
+  </div>
+  <div class="pillar">
+    <h3>Share without signup</h3>
+    <p><code>pathlight share &lt;trace-id&gt;</code> emits a single self-contained HTML file. Zero dependencies to open.</p>
+  </div>
+</section>
+
+<section id="install" class="install">
+  <h2>Start in 30 seconds</h2>
+  <div class="install-grid">
+    <div class="install-card">
+      <p class="eyebrow">Self-host</p>
+      <pre><code>git clone https://github.com/syndicalt/pathlight.git
+cd pathlight
+docker compose up -d</code></pre>
+      <p>Dashboard at <code>localhost:3100</code>, collector at <code>localhost:4100</code>.</p>
+    </div>
+    <div class="install-card">
+      <p class="eyebrow">Instrument — TypeScript</p>
+      <pre><code>npm install @pathlight/sdk</code></pre>
+      <pre><code>import { Pathlight } from "@pathlight/sdk";
+
+const tl = new Pathlight(&#123; baseUrl: "http://localhost:4100" &#125;);
+
+const trace = tl.trace("my-agent", &#123; query &#125;);
+const span = trace.span("llm.chat", "llm", &#123; model: "gpt-4o" &#125;);
+await span.end(&#123; output, inputTokens, outputTokens &#125;);
+await trace.end(&#123; output: final &#125;);</code></pre>
+    </div>
+    <div class="install-card">
+      <p class="eyebrow">Instrument — Python</p>
+      <pre><code>pip install pathlight</code></pre>
+      <pre><code>from pathlight import Pathlight
+
+pl = Pathlight(base_url="http://localhost:4100")
+
+with pl.trace("my-agent", input=&#123;"query": q&#125;) as trace:
+    with trace.span("llm.chat", type="llm", model="gpt-4o") as s:
+        s.end(output=result, input_tokens=50, output_tokens=10)
+    trace.end(output=final)</code></pre>
+    </div>
+  </div>
+</section>
+
+<section class="cta-final">
+  <h2>Stop debugging agents with <code>console.log</code>.</h2>
+  <div class="cta-row">
+    <a href="https://github.com/syndicalt/pathlight" class="btn btn-primary">Get Pathlight</a>
+    <a href="https://github.com/syndicalt/pathlight/blob/master/README.md" class="btn btn-ghost">Read the docs</a>
+  </div>
+</section>
+
+</main>
+
+<footer>
+  <div class="footer-grid">
+    <div>
+      <p class="brand"><span class="brand-accent">Path</span>light</p>
+      <p class="footer-muted">v0.2.0 · MIT</p>
+    </div>
+    <div>
+      <p class="footer-heading">Install</p>
+      <a href="https://www.npmjs.com/package/@pathlight/sdk">@pathlight/sdk</a>
+      <a href="https://pypi.org/project/pathlight/">pathlight (PyPI)</a>
+      <a href="https://www.npmjs.com/package/@pathlight/eval">@pathlight/eval</a>
+      <a href="https://www.npmjs.com/package/@pathlight/cli">@pathlight/cli</a>
+    </div>
+    <div>
+      <p class="footer-heading">Project</p>
+      <a href="https://github.com/syndicalt/pathlight">GitHub</a>
+      <a href="https://github.com/syndicalt/pathlight/issues">Issues</a>
+      <a href="https://github.com/syndicalt/pathlight/blob/master/CHANGELOG.md">Changelog</a>
+    </div>
+    <div>
+      <p class="footer-heading">Docs</p>
+      <a href="https://github.com/syndicalt/pathlight/blob/master/docs/docker.md">Docker</a>
+      <a href="https://github.com/syndicalt/pathlight/blob/master/docs/breakpoints.md">Breakpoints</a>
+      <a href="https://github.com/syndicalt/pathlight/blob/master/docs/replay.md">Replay</a>
+      <a href="https://github.com/syndicalt/pathlight/blob/master/docs/trace-diff.md">Trace diff</a>
+      <a href="https://github.com/syndicalt/pathlight/blob/master/docs/opentelemetry.md">OpenTelemetry</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+// Copy-to-clipboard for the install pill.
+for (const btn of document.querySelectorAll("[data-copy]")) {
+  btn.addEventListener("click", () => {
+    navigator.clipboard.writeText(btn.getAttribute("data-copy") || "");
+    const original = btn.textContent;
+    btn.textContent = "Copied";
+    setTimeout(() => (btn.textContent = original), 1200);
+  });
+}
+</script>
+
+</body>
+</html>

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,540 @@
+/* Pathlight landing page — dark, terminal-adjacent, type-forward. */
+
+:root {
+  color-scheme: dark;
+  --bg: #09090b;
+  --panel: #18181b;
+  --panel-hi: #27272a;
+  --border: #2a2a30;
+  --border-hi: #3f3f46;
+  --text: #e4e4e7;
+  --text-dim: #a1a1aa;
+  --text-mute: #71717a;
+  --text-faint: #52525b;
+  --accent: #60a5fa;
+  --accent-hi: #93c5fd;
+  --accent-bg: rgba(59, 130, 246, 0.15);
+  --accent-border: rgba(59, 130, 246, 0.35);
+  --ok: #6ee7b7;
+  --warn: #fbbf24;
+  --danger: #fca5a5;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Subtle dotted grid behind everything. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 24px 24px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+main, nav, footer { position: relative; z-index: 1; }
+
+a { color: inherit; text-decoration: none; }
+code { font-family: var(--mono); font-size: 0.9em; }
+
+.brand { font-size: 18px; font-weight: 700; letter-spacing: -0.01em; color: var(--text); }
+.brand-accent { color: var(--accent); }
+
+/* ------------- Nav ------------- */
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px clamp(24px, 5vw, 48px);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+.nav-links { display: flex; gap: 24px; align-items: center; }
+.nav-links a {
+  color: var(--text-dim);
+  font-size: 14px;
+  transition: color .15s;
+}
+.nav-links a:hover { color: var(--text); }
+.nav-cta {
+  color: var(--text) !important;
+  padding: 6px 14px;
+  border: 1px solid var(--border-hi);
+  border-radius: 8px;
+  font-weight: 500;
+}
+.nav-cta:hover { border-color: var(--accent); color: var(--accent) !important; }
+
+/* ------------- Hero ------------- */
+.hero {
+  max-width: 1200px;
+  margin: 40px auto 80px;
+  padding: 40px clamp(24px, 5vw, 48px) 80px;
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 72px;
+  align-items: center;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin: 0 0 24px;
+}
+.eyebrow .dot {
+  width: 6px; height: 6px; border-radius: 999px;
+  background: var(--ok);
+  box-shadow: 0 0 8px var(--ok);
+  animation: pulse 2s ease-in-out infinite;
+}
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+h1 {
+  font-size: clamp(40px, 5.5vw, 68px);
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+  margin: 0 0 24px;
+}
+.highlight {
+  background: linear-gradient(120deg, var(--accent) 0%, var(--accent-hi) 60%, #c4b5fd 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.tagline {
+  font-size: 18px;
+  color: var(--text-dim);
+  max-width: 520px;
+  margin: 0 0 36px;
+}
+
+.cta-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 0 0 24px;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 500;
+  border: 1px solid transparent;
+  transition: transform .1s, background .15s, border-color .15s;
+}
+.btn-primary {
+  background: var(--accent);
+  color: #09090b;
+}
+.btn-primary:hover { background: var(--accent-hi); transform: translateY(-1px); }
+.btn-ghost {
+  color: var(--text);
+  border-color: var(--border-hi);
+}
+.btn-ghost:hover { border-color: var(--text-dim); background: var(--panel); }
+
+.install-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 12px 10px 18px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.install-pill code { color: var(--text); }
+.install-pill code::before { content: "$ "; color: var(--text-faint); }
+.copy {
+  background: var(--panel-hi);
+  border: 1px solid var(--border-hi);
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.copy:hover { color: var(--text); border-color: var(--text-dim); }
+
+/* ------------- Hero visual: animated waterfall ------------- */
+.hero-visual {
+  position: relative;
+}
+.wf-frame {
+  background: #0e0e11;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 30px 60px -20px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(96, 165, 250, 0.08);
+  animation: lift 0.8s ease-out both;
+}
+@keyframes lift {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.wf-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  background: #0a0a0c;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.wf-titlebar .dot-red,
+.wf-titlebar .dot-amber,
+.wf-titlebar .dot-green {
+  width: 10px; height: 10px; border-radius: 999px;
+}
+.wf-titlebar .dot-red { background: #ef4444; }
+.wf-titlebar .dot-amber { background: #f59e0b; }
+.wf-titlebar .dot-green { background: #10b981; }
+.wf-title { margin-left: 8px; font-family: var(--mono); color: var(--text); }
+.wf-badge {
+  margin-left: auto;
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--ok);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.wf-axis {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 16px 2px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-faint);
+  border-bottom: 1px solid rgba(42, 42, 48, 0.5);
+}
+
+.wf-row {
+  display: grid;
+  grid-template-columns: 40px 1fr 2.5fr;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 16px;
+  border-bottom: 1px solid rgba(42, 42, 48, 0.3);
+  font-size: 12px;
+  animation: row-in 0.4s ease-out both;
+}
+.wf-row:nth-child(3) { animation-delay: 0.1s; }
+.wf-row:nth-child(4) { animation-delay: 0.25s; }
+.wf-row:nth-child(5) { animation-delay: 0.4s; }
+.wf-row:nth-child(6) { animation-delay: 0.55s; }
+.wf-row:nth-child(7) { animation-delay: 0.7s; }
+.wf-row:nth-child(8) { animation-delay: 0.85s; }
+.wf-row:nth-child(9) { animation-delay: 1s; }
+@keyframes row-in {
+  from { opacity: 0; transform: translateX(-4px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+.wf-row.wf-highlight { background: rgba(96, 165, 250, 0.06); }
+
+.wf-type {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-align: center;
+  font-weight: 600;
+}
+.wf-type.t-llm { background: rgba(59, 130, 246, 0.2); color: #93c5fd; }
+.wf-type.t-tool { background: rgba(16, 185, 129, 0.2); color: #6ee7b7; }
+.wf-type.t-retrieval { background: rgba(139, 92, 246, 0.2); color: #c4b5fd; }
+
+.wf-name {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wf-bar {
+  position: relative;
+  height: 10px;
+  background: rgba(63, 63, 70, 0.4);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.wf-fill {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 3px;
+  opacity: 0.85;
+  animation: fill 0.5s cubic-bezier(.2,.7,.3,1) both;
+  transform-origin: left;
+}
+.wf-row:nth-child(3) .wf-fill { animation-delay: 0.15s; }
+.wf-row:nth-child(4) .wf-fill { animation-delay: 0.3s; }
+.wf-row:nth-child(5) .wf-fill { animation-delay: 0.45s; }
+.wf-row:nth-child(6) .wf-fill { animation-delay: 0.6s; }
+.wf-row:nth-child(7) .wf-fill { animation-delay: 0.75s; }
+.wf-row:nth-child(8) .wf-fill { animation-delay: 0.9s; }
+.wf-row:nth-child(9) .wf-fill { animation-delay: 1.05s; }
+@keyframes fill { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+.wf-fill.t-llm { background: #3b82f6; }
+.wf-fill.t-tool { background: #10b981; }
+.wf-fill.t-retrieval { background: #8b5cf6; }
+
+/* ------------- Features ------------- */
+.features {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 40px clamp(24px, 5vw, 48px) 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 120px;
+}
+
+.feature {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 64px;
+  align-items: center;
+}
+.feature.flip .feature-media { order: -1; }
+
+.feature-text h2 {
+  font-size: clamp(28px, 3vw, 38px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin: 0 0 20px;
+}
+.feature-text p {
+  font-size: 16px;
+  color: var(--text-dim);
+  margin: 0;
+}
+.feature-text code {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+  color: var(--accent-hi);
+}
+.feature-media {
+  position: relative;
+}
+.feature-media img {
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 60px -20px rgba(0, 0, 0, 0.7);
+  background: var(--panel);
+}
+
+/* ------------- Pillar grid ------------- */
+.pillars {
+  max-width: 1200px;
+  margin: 120px auto 40px;
+  padding: 0 clamp(24px, 5vw, 48px);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+.pillar {
+  padding: 24px;
+  background: rgba(24, 24, 27, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  transition: border-color .15s, transform .15s;
+}
+.pillar:hover { border-color: var(--border-hi); transform: translateY(-2px); }
+.pillar h3 {
+  font-size: 15px;
+  letter-spacing: -0.01em;
+  margin: 0 0 8px;
+  color: var(--text);
+}
+.pillar p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-dim);
+}
+.pillar code {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 12.5px;
+  color: var(--accent-hi);
+}
+
+/* ------------- Install ------------- */
+.install {
+  max-width: 1200px;
+  margin: 120px auto 40px;
+  padding: 0 clamp(24px, 5vw, 48px);
+}
+.install h2 {
+  font-size: clamp(28px, 3vw, 38px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 40px;
+}
+.install-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 20px;
+}
+.install-card {
+  padding: 24px;
+  background: rgba(24, 24, 27, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+.install-card .eyebrow { margin: 0 0 16px; }
+.install-card pre {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin: 0 0 12px;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text);
+}
+.install-card p {
+  font-size: 13px;
+  color: var(--text-mute);
+  margin: 12px 0 0;
+}
+.install-card code {
+  background: var(--panel-hi);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--accent-hi);
+}
+
+/* ------------- Final CTA ------------- */
+.cta-final {
+  max-width: 900px;
+  margin: 120px auto 80px;
+  padding: 60px clamp(24px, 5vw, 48px);
+  text-align: center;
+  border-top: 1px solid var(--border);
+}
+.cta-final h2 {
+  font-size: clamp(28px, 3.5vw, 42px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 32px;
+}
+.cta-final code {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 0.85em;
+  color: var(--text-dim);
+}
+.cta-final .cta-row { justify-content: center; }
+
+/* ------------- Footer ------------- */
+footer {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 40px clamp(24px, 5vw, 48px) 60px;
+  border-top: 1px solid var(--border);
+}
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 40px;
+}
+.footer-grid a {
+  display: block;
+  color: var(--text-dim);
+  font-size: 13px;
+  padding: 4px 0;
+  transition: color .15s;
+}
+.footer-grid a:hover { color: var(--accent); }
+.footer-heading {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin: 0 0 12px;
+}
+.footer-muted {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text-faint);
+  margin: 6px 0 0;
+}
+
+/* ------------- Responsive ------------- */
+@media (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+    gap: 48px;
+    margin-top: 24px;
+    padding-bottom: 60px;
+  }
+  .feature, .feature.flip {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+  .feature.flip .feature-media { order: 0; }
+  .features { gap: 72px; padding-bottom: 60px; }
+  .pillars, .install, .cta-final { margin-top: 72px; }
+}
+
+@media (max-width: 520px) {
+  .nav-links a:not(.nav-cta) { display: none; }
+  .install-pill { flex-wrap: wrap; }
+}
+
+/* Respect prefers-reduced-motion — turn off the entry choreography. */
+@media (prefers-reduced-motion: reduce) {
+  .wf-row, .wf-fill, .wf-frame { animation: none !important; }
+  .eyebrow .dot { animation: none; }
+}


### PR DESCRIPTION
## Summary
- Zero-build static hero at \`site/\` — HTML + CSS only
- Animated pure-CSS waterfall visual (no image needed for the fold)
- Three feature sections with tagged screenshot slots
- Install section with Docker + TS + Python snippets
- Social preview meta tags; inline-SVG favicon

## Screenshot slots
Drop PNGs into \`site/assets/\`:
- \`og-cover.png\` — social preview
- \`replay.png\` — LLM replay editor
- \`breakpoint.png\` — breakpoint panel
- \`diff.png\` — trace compare view

Full shot list + descriptions in \`site/README.md\`.

## Deploy
Workflow at \`.github/workflows/pages.yml\` publishes via GitHub Pages on every push to master that touches \`site/**\`. **First-time setup required**: Settings → Pages → Source = "GitHub Actions".

## Preview locally
\`cd site && python3 -m http.server 8000\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)