### PR TITLE
fix(site): explicit robots.txt for social scrapers

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -21,6 +21,7 @@
 <meta name="twitter:title" content="Pathlight — a debugger for AI agents" />
 <meta name="twitter:description" content="Visual traces, live breakpoints, prompt replay. Self-hosted, open source." />
 
+<link rel="canonical" href="https://syndicalt.github.io/pathlight/" />
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='6' cy='6' r='2' fill='%2360a5fa'/%3E%3Ccircle cx='18' cy='6' r='2' fill='%23e4e4e7'/%3E%3Ccircle cx='18' cy='18' r='2' fill='%23e4e4e7'/%3E%3Cpath d='M8 6h6a4 4 0 014 4v8' stroke='%23e4e4e7' stroke-width='2' stroke-linecap='round' fill='none'/%3E%3C/svg%3E" />
 
 <link rel="stylesheet" href="style.css" />

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,23 @@
+# Pathlight landing page — allow everything, including social card scrapers.
+# Unfurlers and crawlers alike.
+
+User-agent: *
+Allow: /
+
+User-agent: facebookexternalhit
+Allow: /
+
+User-agent: Facebot
+Allow: /
+
+User-agent: Twitterbot
+Allow: /
+
+User-agent: LinkedInBot
+Allow: /
+
+User-agent: Slackbot
+Allow: /
+
+User-agent: Discordbot
+Allow: /


### PR DESCRIPTION
Adds explicit allow-all robots.txt and rel=canonical so Facebook's scraper stops surfacing its 'could be robots.txt block' generic error.