### PR TITLE
feat(#42): OpenClaw plugin (@pathlight/openclaw) v1

### DIFF
--- a/examples/openclaw-hello-world/.env.example
+++ b/examples/openclaw-hello-world/.env.example
@@ -1,0 +1,3 @@
+PATHLIGHT_BASE_URL=http://localhost:4100
+PATHLIGHT_PROJECT_ID=openclaw-hello-world
+# PATHLIGHT_API_KEY=pk_live_...   # only required for authenticated collectors

--- a/examples/openclaw-hello-world/README.md
+++ b/examples/openclaw-hello-world/README.md
@@ -1,0 +1,46 @@
+# openclaw-hello-world
+
+Minimal OpenClaw agent wired up with `@pathlight/openclaw` for tracing. Runs
+one LLM call and one tool call, and both land in the Pathlight dashboard.
+
+## Prerequisites
+
+1. A running Pathlight collector + web UI:
+   ```bash
+   docker compose up -d   # from the pathlight repo root
+   # Dashboard: http://localhost:3100
+   # Collector: http://localhost:4100
+   ```
+2. OpenClaw installed on your machine (see [openclaw.ai](https://openclaw.ai)).
+3. An LLM provider configured in OpenClaw (OpenAI, Anthropic, etc.).
+
+## Run
+
+```bash
+export PATHLIGHT_BASE_URL=http://localhost:4100
+export PATHLIGHT_PROJECT_ID=openclaw-hello-world
+
+cd examples/openclaw-hello-world
+openclaw plugins install @pathlight/openclaw
+openclaw run agent.md "What time is it in Tokyo?"
+```
+
+Open http://localhost:3100 — the run appears as a trace with:
+
+- Root span: the agent run, tagged with the git commit you ran from
+- An `llm` child span: the model call that resolved the time-zone query
+- A `tool` child span: the `get_time` tool invocation
+
+## What's in here
+
+- `agent.md` — an OpenClaw agent definition with one LLM step and one tool call.
+- `.env.example` — copy to `.env` and fill in your collector details.
+
+## Troubleshooting
+
+If no traces appear, check:
+
+1. `curl http://localhost:4100/v1/health` — collector reachable?
+2. `openclaw plugins list` — is `@pathlight/openclaw` enabled?
+3. Plugin logs on agent startup will say `pathlight: tracing enabled (<baseUrl>)`.
+   Missing that line means the plugin didn't load.

--- a/examples/openclaw-hello-world/agent.md
+++ b/examples/openclaw-hello-world/agent.md
@@ -1,0 +1,13 @@
+---
+name: hello-world
+description: Answer a time-zone question using one LLM call and one tool.
+tools:
+  - get_time
+---
+
+# Hello World
+
+You are a concise assistant that answers time-zone questions.
+
+When asked what time it is somewhere, call the `get_time` tool with the IANA
+timezone (for example `Asia/Tokyo`) and report the result.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1362,6 +1362,10 @@
       "resolved": "packages/eval",
       "link": true
     },
+    "node_modules/@pathlight/openclaw": {
+      "resolved": "packages/openclaw-plugin",
+      "link": true
+    },
     "node_modules/@pathlight/sdk": {
       "resolved": "packages/sdk",
       "link": true
@@ -5112,6 +5116,18 @@
       "license": "MIT",
       "bin": {
         "pathlight-eval": "bin/pathlight-eval.js"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.0",
+        "vitest": "^4.1.4"
+      }
+    },
+    "packages/openclaw-plugin": {
+      "name": "@pathlight/openclaw",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@pathlight/sdk": "^0.2.0"
       },
       "devDependencies": {
         "typescript": "^5.7.0",

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -1,0 +1,55 @@
+# @pathlight/openclaw
+
+Pathlight tracing plugin for [OpenClaw](https://openclaw.ai). Captures agent
+runs, LLM calls, tool execution, and sub-agent delegation as Pathlight traces —
+with git provenance baked in — and zero code changes in your agent.
+
+## Install
+
+```bash
+openclaw plugins install @pathlight/openclaw
+```
+
+## Configure
+
+Point the plugin at your Pathlight collector via env vars:
+
+```bash
+export PATHLIGHT_BASE_URL=http://localhost:4100
+export PATHLIGHT_API_KEY=pk_live_...        # optional for local collectors
+export PATHLIGHT_PROJECT_ID=proj_xyz        # optional
+```
+
+Or in your OpenClaw plugin config (precedence: plugin config > env > defaults):
+
+```json
+{
+  "pathlight": {
+    "baseUrl": "https://collector.example.com",
+    "apiKey": "pk_live_...",
+    "projectId": "proj_xyz"
+  }
+}
+```
+
+Defaults: `baseUrl=http://localhost:4100`, no API key, no project ID.
+
+## What gets traced
+
+| OpenClaw event | Pathlight span |
+|---|---|
+| `before_agent_start` → `agent_end` | Root trace (with `git_commit` / `git_branch` / `git_dirty`) |
+| `llm_input` → `llm_output` | `llm` span with model, provider, input/output, token usage |
+| `before_tool_call` → `after_tool_call` | `tool` span with name, args, result |
+| `subagent_spawning` → `subagent_ended` | `agent` span in the parent trace (the child run gets its own trace) |
+
+Memory hooks are intentionally out of scope in v1.
+
+## Graceful degradation
+
+If the collector is unreachable, the plugin logs one warning and continues
+best-effort. A downed collector never crashes the agent.
+
+## License
+
+MIT

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@pathlight/openclaw",
+  "version": "0.1.0",
+  "description": "Pathlight tracing plugin for OpenClaw — agent runs, LLM calls, tool execution, and sub-agent delegation as Pathlight traces with git provenance.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "openclaw": {
+    "extensions": ["./dist/index.js"],
+    "compat": {
+      "pluginApi": ">=2026.3.24-beta.2",
+      "minGatewayVersion": "2026.3.24-beta.2"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "openclaw",
+    "plugin",
+    "pathlight",
+    "tracing",
+    "observability",
+    "ai",
+    "agent",
+    "llm"
+  ],
+  "author": "Nicholas Blanchard",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/syndicalt/pathlight.git",
+    "directory": "packages/openclaw-plugin"
+  },
+  "homepage": "https://github.com/syndicalt/pathlight",
+  "dependencies": {
+    "@pathlight/sdk": "^0.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -1,0 +1,22 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+
+export interface PathlightOpenClawOptions {
+  baseUrl?: string;
+  apiKey?: string;
+  projectId?: string;
+}
+
+export interface ResolvedOptions {
+  baseUrl: string;
+  apiKey: string | undefined;
+  projectId: string | undefined;
+}
+
+export function resolveOptions(api: OpenClawPluginApi): ResolvedOptions {
+  const cfg = (api.pluginConfig ?? {}) as PathlightOpenClawOptions;
+  return {
+    baseUrl: cfg.baseUrl ?? process.env.PATHLIGHT_BASE_URL ?? "http://localhost:4100",
+    apiKey: cfg.apiKey ?? process.env.PATHLIGHT_API_KEY,
+    projectId: cfg.projectId ?? process.env.PATHLIGHT_PROJECT_ID,
+  };
+}

--- a/packages/openclaw-plugin/src/hooks/delegation.ts
+++ b/packages/openclaw-plugin/src/hooks/delegation.ts
@@ -1,8 +1,12 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginState } from "../state.js";
+import { silence } from "../safe.js";
 
-export function registerDelegationHooks(api: OpenClawPluginApi, state: PluginState): void {
-  api.on("subagent_spawning", async (event, ctx) => {
+type SafeOn = ReturnType<typeof import("../safe.js").createSafeOn>;
+type Logger = OpenClawPluginApi["logger"];
+
+export function registerDelegationHooks(safeOn: SafeOn, _logger: Logger, state: PluginState): void {
+  safeOn("subagent_spawning", async (event, ctx) => {
     const parentRunId = ctx.runId;
     const childSessionKey = event.childSessionKey;
     if (!parentRunId || !childSessionKey) return;
@@ -21,24 +25,21 @@ export function registerDelegationHooks(api: OpenClawPluginApi, state: PluginSta
         parentRunId,
       },
     });
+    silence(span);
     state.setSubagentSpan(childSessionKey, span);
   });
 
-  api.on("subagent_ended", async (event, _ctx) => {
+  safeOn("subagent_ended", async (event, _ctx) => {
     const childSessionKey = event.targetSessionKey;
     if (!childSessionKey) return;
     const span = state.takeSubagentSpan(childSessionKey);
     if (!span) return;
 
     const failed = event.outcome === "error" || event.outcome === "timeout" || event.outcome === "killed";
-    try {
-      await span.end({
-        output: { reason: event.reason, outcome: event.outcome },
-        error: event.error,
-        status: failed ? "failed" : "completed",
-      });
-    } catch (err) {
-      api.logger.warn("pathlight: subagent span.end failed", { childSessionKey, err: String(err) });
-    }
+    await span.end({
+      output: { reason: event.reason, outcome: event.outcome },
+      error: event.error,
+      status: failed ? "failed" : "completed",
+    });
   });
 }

--- a/packages/openclaw-plugin/src/hooks/delegation.ts
+++ b/packages/openclaw-plugin/src/hooks/delegation.ts
@@ -1,0 +1,44 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginState } from "../state.js";
+
+export function registerDelegationHooks(api: OpenClawPluginApi, state: PluginState): void {
+  api.on("subagent_spawning", async (event, ctx) => {
+    const parentRunId = ctx.runId;
+    const childSessionKey = event.childSessionKey;
+    if (!parentRunId || !childSessionKey) return;
+    const parentTrace = state.getTrace(parentRunId);
+    if (!parentTrace) return;
+
+    const span = parentTrace.span(event.agentId, "agent", {
+      input: {
+        childSessionKey: event.childSessionKey,
+        agentId: event.agentId,
+        label: event.label,
+        mode: event.mode,
+      },
+      metadata: {
+        openclawChildSessionKey: childSessionKey,
+        parentRunId,
+      },
+    });
+    state.setSubagentSpan(childSessionKey, span);
+  });
+
+  api.on("subagent_ended", async (event, _ctx) => {
+    const childSessionKey = event.targetSessionKey;
+    if (!childSessionKey) return;
+    const span = state.takeSubagentSpan(childSessionKey);
+    if (!span) return;
+
+    const failed = event.outcome === "error" || event.outcome === "timeout" || event.outcome === "killed";
+    try {
+      await span.end({
+        output: { reason: event.reason, outcome: event.outcome },
+        error: event.error,
+        status: failed ? "failed" : "completed",
+      });
+    } catch (err) {
+      api.logger.warn("pathlight: subagent span.end failed", { childSessionKey, err: String(err) });
+    }
+  });
+}

--- a/packages/openclaw-plugin/src/hooks/llm.ts
+++ b/packages/openclaw-plugin/src/hooks/llm.ts
@@ -1,8 +1,12 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginState } from "../state.js";
+import { silence } from "../safe.js";
 
-export function registerLlmHooks(api: OpenClawPluginApi, state: PluginState): void {
-  api.on("llm_input", async (event, ctx) => {
+type SafeOn = ReturnType<typeof import("../safe.js").createSafeOn>;
+type Logger = OpenClawPluginApi["logger"];
+
+export function registerLlmHooks(safeOn: SafeOn, _logger: Logger, state: PluginState): void {
+  safeOn("llm_input", async (event, ctx) => {
     const runId = event.runId ?? ctx.runId;
     if (!runId) return;
     const trace = state.getTrace(runId);
@@ -18,23 +22,20 @@ export function registerLlmHooks(api: OpenClawPluginApi, state: PluginState): vo
         imagesCount: event.imagesCount,
       },
     });
+    silence(span);
     state.setLlmSpan(runId, span);
   });
 
-  api.on("llm_output", async (event, ctx) => {
+  safeOn("llm_output", async (event, ctx) => {
     const runId = event.runId ?? ctx.runId;
     if (!runId) return;
     const span = state.takeLlmSpan(runId);
     if (!span) return;
 
-    try {
-      await span.end({
-        output: event.assistantTexts,
-        inputTokens: event.usage?.input,
-        outputTokens: event.usage?.output,
-      });
-    } catch (err) {
-      api.logger.warn("pathlight: llm span.end failed", { runId, err: String(err) });
-    }
+    await span.end({
+      output: event.assistantTexts,
+      inputTokens: event.usage?.input,
+      outputTokens: event.usage?.output,
+    });
   });
 }

--- a/packages/openclaw-plugin/src/hooks/llm.ts
+++ b/packages/openclaw-plugin/src/hooks/llm.ts
@@ -1,0 +1,40 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginState } from "../state.js";
+
+export function registerLlmHooks(api: OpenClawPluginApi, state: PluginState): void {
+  api.on("llm_input", async (event, ctx) => {
+    const runId = event.runId ?? ctx.runId;
+    if (!runId) return;
+    const trace = state.getTrace(runId);
+    if (!trace) return;
+
+    const span = trace.span(`llm.${event.model}`, "llm", {
+      model: event.model,
+      provider: event.provider,
+      input: {
+        prompt: event.prompt,
+        systemPrompt: event.systemPrompt,
+        historyMessages: event.historyMessages,
+        imagesCount: event.imagesCount,
+      },
+    });
+    state.setLlmSpan(runId, span);
+  });
+
+  api.on("llm_output", async (event, ctx) => {
+    const runId = event.runId ?? ctx.runId;
+    if (!runId) return;
+    const span = state.takeLlmSpan(runId);
+    if (!span) return;
+
+    try {
+      await span.end({
+        output: event.assistantTexts,
+        inputTokens: event.usage?.input,
+        outputTokens: event.usage?.output,
+      });
+    } catch (err) {
+      api.logger.warn("pathlight: llm span.end failed", { runId, err: String(err) });
+    }
+  });
+}

--- a/packages/openclaw-plugin/src/hooks/tool.ts
+++ b/packages/openclaw-plugin/src/hooks/tool.ts
@@ -1,8 +1,12 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginState } from "../state.js";
+import { silence } from "../safe.js";
 
-export function registerToolHooks(api: OpenClawPluginApi, state: PluginState): void {
-  api.on("before_tool_call", async (event, ctx) => {
+type SafeOn = ReturnType<typeof import("../safe.js").createSafeOn>;
+type Logger = OpenClawPluginApi["logger"];
+
+export function registerToolHooks(safeOn: SafeOn, _logger: Logger, state: PluginState): void {
+  safeOn("before_tool_call", async (event, ctx) => {
     const runId = event.runId ?? ctx.runId;
     const toolCallId = event.toolCallId;
     if (!runId || !toolCallId) return;
@@ -14,24 +18,21 @@ export function registerToolHooks(api: OpenClawPluginApi, state: PluginState): v
       toolArgs: event.params,
       input: event.params,
     });
+    silence(span);
     state.setToolSpan(toolCallId, span);
   });
 
-  api.on("after_tool_call", async (event, ctx) => {
+  safeOn("after_tool_call", async (event, _ctx) => {
     const toolCallId = event.toolCallId;
     if (!toolCallId) return;
     const span = state.takeToolSpan(toolCallId);
     if (!span) return;
 
-    try {
-      await span.end({
-        output: event.result,
-        toolResult: event.result,
-        error: event.error,
-        status: event.error ? "failed" : "completed",
-      });
-    } catch (err) {
-      api.logger.warn("pathlight: tool span.end failed", { toolCallId, err: String(err) });
-    }
+    await span.end({
+      output: event.result,
+      toolResult: event.result,
+      error: event.error,
+      status: event.error ? "failed" : "completed",
+    });
   });
 }

--- a/packages/openclaw-plugin/src/hooks/tool.ts
+++ b/packages/openclaw-plugin/src/hooks/tool.ts
@@ -1,0 +1,37 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginState } from "../state.js";
+
+export function registerToolHooks(api: OpenClawPluginApi, state: PluginState): void {
+  api.on("before_tool_call", async (event, ctx) => {
+    const runId = event.runId ?? ctx.runId;
+    const toolCallId = event.toolCallId;
+    if (!runId || !toolCallId) return;
+    const trace = state.getTrace(runId);
+    if (!trace) return;
+
+    const span = trace.span(event.toolName, "tool", {
+      toolName: event.toolName,
+      toolArgs: event.params,
+      input: event.params,
+    });
+    state.setToolSpan(toolCallId, span);
+  });
+
+  api.on("after_tool_call", async (event, ctx) => {
+    const toolCallId = event.toolCallId;
+    if (!toolCallId) return;
+    const span = state.takeToolSpan(toolCallId);
+    if (!span) return;
+
+    try {
+      await span.end({
+        output: event.result,
+        toolResult: event.result,
+        error: event.error,
+        status: event.error ? "failed" : "completed",
+      });
+    } catch (err) {
+      api.logger.warn("pathlight: tool span.end failed", { toolCallId, err: String(err) });
+    }
+  });
+}

--- a/packages/openclaw-plugin/src/hooks/trace-envelope.ts
+++ b/packages/openclaw-plugin/src/hooks/trace-envelope.ts
@@ -1,0 +1,44 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginState } from "../state.js";
+
+export function registerTraceEnvelopeHooks(api: OpenClawPluginApi, state: PluginState): void {
+  api.on("before_agent_start", async (event, ctx) => {
+    const runId = ctx.runId;
+    if (!runId) return;
+
+    const trace = state.client.trace(
+      ctx.agentId ?? "openclaw-agent",
+      event,
+      {
+        metadata: {
+          openclawRunId: runId,
+          sessionKey: ctx.sessionKey,
+          sessionId: ctx.sessionId,
+          agentId: ctx.agentId,
+          modelProviderId: ctx.modelProviderId,
+          modelId: ctx.modelId,
+          trigger: ctx.trigger,
+          channelId: ctx.channelId,
+        },
+      },
+    );
+    state.setTrace(runId, trace);
+  });
+
+  api.on("agent_end", async (event, ctx) => {
+    const runId = ctx.runId;
+    if (!runId) return;
+    const trace = state.removeTrace(runId);
+    if (!trace) return;
+
+    try {
+      await trace.end({
+        output: event.messages,
+        status: event.success ? "completed" : "failed",
+        error: event.error,
+      });
+    } catch (err) {
+      api.logger.warn("pathlight: trace.end failed", { runId, err: String(err) });
+    }
+  });
+}

--- a/packages/openclaw-plugin/src/hooks/trace-envelope.ts
+++ b/packages/openclaw-plugin/src/hooks/trace-envelope.ts
@@ -1,8 +1,16 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginState } from "../state.js";
+import { silence } from "../safe.js";
 
-export function registerTraceEnvelopeHooks(api: OpenClawPluginApi, state: PluginState): void {
-  api.on("before_agent_start", async (event, ctx) => {
+type SafeOn = ReturnType<typeof import("../safe.js").createSafeOn>;
+type Logger = OpenClawPluginApi["logger"];
+
+export function registerTraceEnvelopeHooks(
+  safeOn: SafeOn,
+  _logger: Logger,
+  state: PluginState,
+): void {
+  safeOn("before_agent_start", async (event, ctx) => {
     const runId = ctx.runId;
     if (!runId) return;
 
@@ -22,23 +30,20 @@ export function registerTraceEnvelopeHooks(api: OpenClawPluginApi, state: Plugin
         },
       },
     );
+    silence(trace);
     state.setTrace(runId, trace);
   });
 
-  api.on("agent_end", async (event, ctx) => {
+  safeOn("agent_end", async (event, ctx) => {
     const runId = ctx.runId;
     if (!runId) return;
     const trace = state.removeTrace(runId);
     if (!trace) return;
 
-    try {
-      await trace.end({
-        output: event.messages,
-        status: event.success ? "completed" : "failed",
-        error: event.error,
-      });
-    } catch (err) {
-      api.logger.warn("pathlight: trace.end failed", { runId, err: String(err) });
-    }
+    await trace.end({
+      output: event.messages,
+      status: event.success ? "completed" : "failed",
+      error: event.error,
+    });
   });
 }

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -1,0 +1,22 @@
+import { Pathlight } from "@pathlight/sdk";
+
+export interface PathlightOpenClawOptions {
+  baseUrl?: string;
+  apiKey?: string;
+  projectId?: string;
+}
+
+export function createPathlightPlugin(options: PathlightOpenClawOptions = {}) {
+  const client = new Pathlight({
+    baseUrl: options.baseUrl ?? "http://localhost:4100",
+    apiKey: options.apiKey,
+    projectId: options.projectId,
+  });
+
+  return {
+    name: "@pathlight/openclaw",
+    client,
+  };
+}
+
+export default createPathlightPlugin;

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -1,4 +1,7 @@
+import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { Pathlight } from "@pathlight/sdk";
+import { PluginState } from "./state.js";
+import { registerTraceEnvelopeHooks } from "./hooks/trace-envelope.js";
 
 export interface PathlightOpenClawOptions {
   baseUrl?: string;
@@ -6,17 +9,32 @@ export interface PathlightOpenClawOptions {
   projectId?: string;
 }
 
-export function createPathlightPlugin(options: PathlightOpenClawOptions = {}) {
-  const client = new Pathlight({
-    baseUrl: options.baseUrl ?? "http://localhost:4100",
-    apiKey: options.apiKey,
-    projectId: options.projectId,
-  });
-
+function resolveOptions(api: OpenClawPluginApi): Required<Pick<PathlightOpenClawOptions, "baseUrl">> & PathlightOpenClawOptions {
+  const cfg = (api.pluginConfig ?? {}) as PathlightOpenClawOptions;
   return {
-    name: "@pathlight/openclaw",
-    client,
+    baseUrl: cfg.baseUrl ?? process.env.PATHLIGHT_BASE_URL ?? "http://localhost:4100",
+    apiKey: cfg.apiKey ?? process.env.PATHLIGHT_API_KEY,
+    projectId: cfg.projectId ?? process.env.PATHLIGHT_PROJECT_ID,
   };
 }
 
-export default createPathlightPlugin;
+export default definePluginEntry({
+  id: "pathlight",
+  name: "Pathlight",
+  description: "Trace OpenClaw agent runs, LLM calls, tool execution, and sub-agent delegation in the Pathlight dashboard.",
+  register(api) {
+    const opts = resolveOptions(api);
+    const client = new Pathlight({
+      baseUrl: opts.baseUrl,
+      apiKey: opts.apiKey,
+      projectId: opts.projectId,
+    });
+    const state = new PluginState(client);
+
+    api.logger.info(`pathlight: tracing enabled (${opts.baseUrl})`);
+
+    registerTraceEnvelopeHooks(api, state);
+  },
+});
+
+export { PluginState };

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -3,6 +3,7 @@ import { Pathlight } from "@pathlight/sdk";
 import { PluginState } from "./state.js";
 import { registerTraceEnvelopeHooks } from "./hooks/trace-envelope.js";
 import { registerLlmHooks } from "./hooks/llm.js";
+import { registerToolHooks } from "./hooks/tool.js";
 
 export interface PathlightOpenClawOptions {
   baseUrl?: string;
@@ -36,6 +37,7 @@ export default definePluginEntry({
 
     registerTraceEnvelopeHooks(api, state);
     registerLlmHooks(api, state);
+    registerToolHooks(api, state);
   },
 });
 

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -2,6 +2,7 @@ import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/p
 import { Pathlight } from "@pathlight/sdk";
 import { PluginState } from "./state.js";
 import { registerTraceEnvelopeHooks } from "./hooks/trace-envelope.js";
+import { registerLlmHooks } from "./hooks/llm.js";
 
 export interface PathlightOpenClawOptions {
   baseUrl?: string;
@@ -34,6 +35,7 @@ export default definePluginEntry({
     api.logger.info(`pathlight: tracing enabled (${opts.baseUrl})`);
 
     registerTraceEnvelopeHooks(api, state);
+    registerLlmHooks(api, state);
   },
 });
 

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -1,25 +1,15 @@
-import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { Pathlight } from "@pathlight/sdk";
 import { PluginState } from "./state.js";
+import { resolveOptions } from "./config.js";
+import { createSafeOn } from "./safe.js";
 import { registerTraceEnvelopeHooks } from "./hooks/trace-envelope.js";
 import { registerLlmHooks } from "./hooks/llm.js";
 import { registerToolHooks } from "./hooks/tool.js";
 import { registerDelegationHooks } from "./hooks/delegation.js";
 
-export interface PathlightOpenClawOptions {
-  baseUrl?: string;
-  apiKey?: string;
-  projectId?: string;
-}
-
-function resolveOptions(api: OpenClawPluginApi): Required<Pick<PathlightOpenClawOptions, "baseUrl">> & PathlightOpenClawOptions {
-  const cfg = (api.pluginConfig ?? {}) as PathlightOpenClawOptions;
-  return {
-    baseUrl: cfg.baseUrl ?? process.env.PATHLIGHT_BASE_URL ?? "http://localhost:4100",
-    apiKey: cfg.apiKey ?? process.env.PATHLIGHT_API_KEY,
-    projectId: cfg.projectId ?? process.env.PATHLIGHT_PROJECT_ID,
-  };
-}
+export type { PathlightOpenClawOptions } from "./config.js";
+export { PluginState };
 
 export default definePluginEntry({
   id: "pathlight",
@@ -33,14 +23,13 @@ export default definePluginEntry({
       projectId: opts.projectId,
     });
     const state = new PluginState(client);
+    const safeOn = createSafeOn(api);
 
     api.logger.info(`pathlight: tracing enabled (${opts.baseUrl})`);
 
-    registerTraceEnvelopeHooks(api, state);
-    registerLlmHooks(api, state);
-    registerToolHooks(api, state);
-    registerDelegationHooks(api, state);
+    registerTraceEnvelopeHooks(safeOn, api.logger, state);
+    registerLlmHooks(safeOn, api.logger, state);
+    registerToolHooks(safeOn, api.logger, state);
+    registerDelegationHooks(safeOn, api.logger, state);
   },
 });
-
-export { PluginState };

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -4,6 +4,7 @@ import { PluginState } from "./state.js";
 import { registerTraceEnvelopeHooks } from "./hooks/trace-envelope.js";
 import { registerLlmHooks } from "./hooks/llm.js";
 import { registerToolHooks } from "./hooks/tool.js";
+import { registerDelegationHooks } from "./hooks/delegation.js";
 
 export interface PathlightOpenClawOptions {
   baseUrl?: string;
@@ -38,6 +39,7 @@ export default definePluginEntry({
     registerTraceEnvelopeHooks(api, state);
     registerLlmHooks(api, state);
     registerToolHooks(api, state);
+    registerDelegationHooks(api, state);
   },
 });
 

--- a/packages/openclaw-plugin/src/openclaw.d.ts
+++ b/packages/openclaw-plugin/src/openclaw.d.ts
@@ -1,0 +1,129 @@
+declare module "openclaw/plugin-sdk/plugin-entry" {
+  export type PluginHookAgentContext = {
+    runId?: string;
+    agentId?: string;
+    sessionKey?: string;
+    sessionId?: string;
+    workspaceDir?: string;
+    modelProviderId?: string;
+    modelId?: string;
+    messageProvider?: string;
+    trigger?: string;
+    channelId?: string;
+  };
+
+  export type PluginHookSubagentContext = {
+    runId?: string;
+    childSessionKey?: string;
+    requesterSessionKey?: string;
+  };
+
+  export type PluginHookBeforeAgentStartEvent = Record<string, unknown>;
+
+  export type PluginHookAgentEndEvent = {
+    messages: unknown[];
+    success: boolean;
+    error?: string;
+    durationMs?: number;
+  };
+
+  export type PluginHookLlmInputEvent = {
+    runId: string;
+    sessionId: string;
+    provider: string;
+    model: string;
+    systemPrompt?: string;
+    prompt: string;
+    historyMessages: unknown[];
+    imagesCount: number;
+  };
+
+  export type PluginHookLlmOutputEvent = {
+    runId: string;
+    sessionId: string;
+    provider: string;
+    model: string;
+    resolvedRef?: string;
+    assistantTexts: string[];
+    lastAssistant?: unknown;
+    usage?: {
+      input?: number;
+      output?: number;
+      cacheRead?: number;
+      cacheWrite?: number;
+      total?: number;
+    };
+  };
+
+  export type PluginHookBeforeToolCallEvent = {
+    toolName: string;
+    params: Record<string, unknown>;
+    runId?: string;
+    toolCallId?: string;
+  };
+
+  export type PluginHookAfterToolCallEvent = {
+    toolName: string;
+    params: Record<string, unknown>;
+    runId?: string;
+    toolCallId?: string;
+    result?: unknown;
+    error?: string;
+    durationMs?: number;
+  };
+
+  export type PluginHookSubagentSpawningEvent = {
+    childSessionKey: string;
+    agentId: string;
+    label?: string;
+    mode: "run" | "session";
+  };
+
+  export type PluginHookSubagentEndedEvent = {
+    targetSessionKey: string;
+    targetKind: "subagent" | "acp";
+    reason: string;
+    accountId?: string;
+    runId?: string;
+    endedAt?: number;
+    outcome?: "ok" | "error" | "timeout" | "killed" | "reset" | "deleted";
+    error?: string;
+  };
+
+  export type PluginHookHandlerMap = {
+    before_agent_start: (event: PluginHookBeforeAgentStartEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+    agent_end: (event: PluginHookAgentEndEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+    llm_input: (event: PluginHookLlmInputEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+    llm_output: (event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+    before_tool_call: (event: PluginHookBeforeToolCallEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+    after_tool_call: (event: PluginHookAfterToolCallEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+    subagent_spawning: (event: PluginHookSubagentSpawningEvent, ctx: PluginHookSubagentContext) => Promise<void> | void;
+    subagent_ended: (event: PluginHookSubagentEndedEvent, ctx: PluginHookSubagentContext) => Promise<void> | void;
+  };
+
+  export type PluginHookName = keyof PluginHookHandlerMap;
+
+  export type OpenClawPluginApi = {
+    id: string;
+    name: string;
+    logger: {
+      info: (msg: string, meta?: unknown) => void;
+      warn: (msg: string, meta?: unknown) => void;
+      error: (msg: string, meta?: unknown) => void;
+      debug: (msg: string, meta?: unknown) => void;
+    };
+    pluginConfig?: Record<string, unknown>;
+    on: <K extends PluginHookName>(
+      hookName: K,
+      handler: PluginHookHandlerMap[K],
+      opts?: { priority?: number },
+    ) => void;
+  };
+
+  export function definePluginEntry(options: {
+    id: string;
+    name: string;
+    description: string;
+    register: (api: OpenClawPluginApi) => void;
+  }): unknown;
+}

--- a/packages/openclaw-plugin/src/safe.ts
+++ b/packages/openclaw-plugin/src/safe.ts
@@ -1,0 +1,30 @@
+import type { OpenClawPluginApi, PluginHookHandlerMap, PluginHookName } from "openclaw/plugin-sdk/plugin-entry";
+import type { Trace, Span } from "@pathlight/sdk";
+
+export function createSafeOn(api: OpenClawPluginApi) {
+  let collectorDegraded = false;
+
+  return function safeOn<K extends PluginHookName>(
+    hookName: K,
+    handler: PluginHookHandlerMap[K],
+  ): void {
+    const wrapped = (async (event: unknown, ctx: unknown) => {
+      try {
+        await (handler as (e: unknown, c: unknown) => unknown)(event, ctx);
+      } catch (err) {
+        if (!collectorDegraded) {
+          collectorDegraded = true;
+          api.logger.warn(
+            `pathlight: hook "${hookName}" threw; tracing will continue best-effort`,
+            { err: String(err) },
+          );
+        }
+      }
+    }) as PluginHookHandlerMap[K];
+    api.on(hookName, wrapped);
+  };
+}
+
+export function silence(target: Trace | Span): void {
+  void target.id.catch(() => {});
+}

--- a/packages/openclaw-plugin/src/state.ts
+++ b/packages/openclaw-plugin/src/state.ts
@@ -1,0 +1,55 @@
+import type { Pathlight, Trace, Span } from "@pathlight/sdk";
+
+export class PluginState {
+  private traces = new Map<string, Trace>();
+  private llmSpans = new Map<string, Span>();
+  private toolSpans = new Map<string, Span>();
+  private subagentSpans = new Map<string, Span>();
+
+  constructor(public readonly client: Pathlight) {}
+
+  setTrace(runId: string, trace: Trace): void {
+    this.traces.set(runId, trace);
+  }
+
+  getTrace(runId: string | undefined): Trace | undefined {
+    if (!runId) return undefined;
+    return this.traces.get(runId);
+  }
+
+  removeTrace(runId: string): Trace | undefined {
+    const trace = this.traces.get(runId);
+    if (trace) this.traces.delete(runId);
+    return trace;
+  }
+
+  setLlmSpan(runId: string, span: Span): void {
+    this.llmSpans.set(runId, span);
+  }
+
+  takeLlmSpan(runId: string): Span | undefined {
+    const span = this.llmSpans.get(runId);
+    if (span) this.llmSpans.delete(runId);
+    return span;
+  }
+
+  setToolSpan(toolCallId: string, span: Span): void {
+    this.toolSpans.set(toolCallId, span);
+  }
+
+  takeToolSpan(toolCallId: string): Span | undefined {
+    const span = this.toolSpans.get(toolCallId);
+    if (span) this.toolSpans.delete(toolCallId);
+    return span;
+  }
+
+  setSubagentSpan(childSessionKey: string, span: Span): void {
+    this.subagentSpans.set(childSessionKey, span);
+  }
+
+  takeSubagentSpan(childSessionKey: string): Span | undefined {
+    const span = this.subagentSpans.get(childSessionKey);
+    if (span) this.subagentSpans.delete(childSessionKey);
+    return span;
+  }
+}

--- a/packages/openclaw-plugin/tsconfig.json
+++ b/packages/openclaw-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 42
branch: issue/42-openclaw-plugin
status: resolved
updated_at: 2026-04-24T13:55:26Z
review_status: awaiting-review
-->

## Summary

Adds `@pathlight/openclaw`, a first-party OpenClaw plugin that captures agent runs, LLM calls, tool execution, and sub-agent delegation as Pathlight traces with git provenance. Matches the `@opik/opik-openclaw` competitive baseline minus memory hooks (deferred to v2) and differentiates by surfacing `git_commit` / `git_branch` / `git_dirty` on every trace.

Closes #42

## Review Status

- **Current state:** awaiting review
- **Last reviewed by:** none yet
- **Last reviewed at:** n/a
- **Reviewed commit:** n/a
- **Source artifact:** none yet
- **Needs re-review since:** no

## Journey Timeline

### Initial Plan

See #42 for the full plan: seven tasks (T1 scaffold → T7 example + README), scope = parity minus memory, packaging = monorepo workspace, differentiator = git provenance on every trace.

### What We Discovered

- OpenClaw has **two** hook systems. The generic `api.registerHook(events, handler)` accepts the older `"agent:bootstrap"` / `"message:received"` internal events. The typed plugin hooks (`before_agent_start`, `llm_input`, etc.) use `api.on<K>(hookName, handler)` with per-hook payload types from `PluginHookHandlerMap`. This plugin targets the second surface.
- **Sub-agent delegation doesn't nest inline.** A spawned subagent is a separate run with its own `runId` and its own `before_agent_start` firing, so it gets its own Pathlight trace. v1 emits a marker span of type `agent` in the parent trace carrying `childSessionKey` / `parentRunId` metadata; cross-trace linking via metadata is a future UX pass.
- **Types can be shimmed, not installed.** `openclaw` is not a devDependency — `src/openclaw.d.ts` declares the subset we use. Keeps the package small; the real module is host-provided at runtime.

### Implementation Issues

- None material. Hook API was initially `[unverified]` (three open items in #42); all three resolved during T2 by reading `github.com/openclaw/openclaw@main` directly. Full details in the [hook-verification comment](https://github.com/syndicalt/pathlight/issues/42#issuecomment-4313729797) on #42.

### Key Decisions Made

| Decision | Choice | Why |
|---|---|---|
| v1 scope | Parity minus memory hooks | Memory is fuzziest concept; Opik's own docs don't pin it down. Avoid designing against an unprofiled shape. |
| Packaging | Monorepo workspace (`@pathlight/openclaw`) | Shares Turborepo build + SDK versioning. Standalone repo doubles CI/docs surface with no current benefit. |
| Hook registration API | `api.on<K>(name, handler)` | Typed plugin-hook surface, not the older internal-hooks `registerHook`. Gives per-hook payload types for free. |
| Run correlation | `runId` for trace + LLM; `toolCallId` for tool; `childSessionKey` for delegation | All three are guaranteed stable by OpenClaw for their respective hook pairs. No reconstruction needed. |
| Sub-agent span model | Marker span in parent, separate trace for child | Matches OpenClaw's actual execution model; inline nesting would have required forged parent-child links. |
| OpenClaw dependency | Shimmed via `.d.ts`, not installed | Keeps package install lean; real module comes from the host. |
| Graceful degradation | `createSafeOn` wrapper + span-promise silencing | Never crash the agent on collector outage; log one warning per run when hooks throw. |

### Changes Made

**Commits:**

```
9a14cce docs(#42/T7): plugin README + openclaw-hello-world example
a20e82a feat(#42/T6): config precedence + graceful collector degradation
33773c0 feat(#42/T5): sub-agent delegation span hook (subagent_spawning / subagent_ended)
41d7bd9 feat(#42/T4): tool execution span hook (before_tool_call / after_tool_call)
db0c330 feat(#42/T3): LLM call span hook (llm_input / llm_output)
b07a3df feat(#42/T2): trace envelope hook (before_agent_start / agent_end)
2d2f8fd feat(#42/T1): scaffold @pathlight/openclaw workspace
```

**New package:** `packages/openclaw-plugin/` → `@pathlight/openclaw@0.1.0`
**New example:** `examples/openclaw-hello-world/` (agent.md + README + .env.example)

## Testing

- [x] `npx turbo build` — all 7 packages build clean (new package cache-misses on first build, subsequent builds cached)
- [x] `npx turbo build --filter=@pathlight/openclaw` — passes after every task commit
- [x] Self-audit — hook wiring factored into four focused files (`hooks/trace-envelope.ts`, `hooks/llm.ts`, `hooks/tool.ts`, `hooks/delegation.ts`), shared state in `state.ts`, shared safety in `safe.ts`. No dead code.

**Not yet tested end-to-end against a real OpenClaw install.** The plugin compiles against shimmed types and matches the hook payload shapes verified in OpenClaw source. First real-agent run happens when someone `openclaw plugins install @pathlight/openclaw` — that's the v1 acceptance event and should produce a first trace in the dashboard.

## Stacked PRs / Related

- None.

## Knowledge for Future Reference

- Memory hooks (`memory-core-host-events`, `memory-host-events`) exist in OpenClaw but were deferred. Adding them is the v2 scope — see `PluginHookHandlerMap` in `src/openclaw.d.ts` as the extension point.
- If OpenClaw changes its `compat.pluginApi` baseline, bump `openclaw.compat.pluginApi` in `packages/openclaw-plugin/package.json`. Currently pinned at `>=2026.3.24-beta.2`.
- `src/openclaw.d.ts` is a hand-maintained subset of OpenClaw's real types. If payloads change upstream, update this file — runtime errors from mismatched shapes will otherwise be silent thanks to `createSafeOn`.

---
Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
