### PR TITLE
feat(#49): Dashboard Fix-this button + diff preview [stack: #45, #47, #48]

### DIFF
--- a/apps/web/src/app/traces/[id]/page.tsx
+++ b/apps/web/src/app/traces/[id]/page.tsx
@@ -5,6 +5,8 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { fetchApi, patchApi } from "../../../lib/api";
 import { formatDuration, formatTokens } from "../../../lib/format";
+import { FixButton } from "../../../components/Fix/FixButton";
+import { FixDialog, type FixContext } from "../../../components/Fix/FixDialog";
 
 interface Trace {
   id: string;
@@ -101,11 +103,12 @@ function JsonBlock({ data, label }: { data: unknown; label: string }) {
   );
 }
 
-function SpanInspector({ span, onClose }: { span: Span; onClose: () => void }) {
+function SpanInspector({ span, onClose, onFix }: { span: Span; onClose: () => void; onFix: () => void }) {
   const style = TYPE_STYLES[span.type] || TYPE_STYLES.custom;
   const meta = parseJson(span.metadata) as Record<string, unknown> | null;
   const source = meta?._source as { file?: string; line?: number; func?: string } | undefined;
   const isLlm = span.type === "llm";
+  const canFix = spanHasIssues(span);
 
   return (
     <aside className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden flex flex-col">
@@ -122,11 +125,14 @@ function SpanInspector({ span, onClose }: { span: Span; onClose: () => void }) {
         {(span.inputTokens || span.outputTokens) ? (
           <span className="text-xs text-zinc-500 font-mono shrink-0">{span.inputTokens || 0}/{span.outputTokens || 0} tok</span>
         ) : null}
-        <button onClick={onClose} className="ml-auto text-zinc-500 hover:text-zinc-300 shrink-0" aria-label="Close inspector">
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
+        <div className="ml-auto flex items-center gap-2 shrink-0">
+          <FixButton visible={canFix} onClick={onFix} />
+          <button onClick={onClose} className="text-zinc-500 hover:text-zinc-300" aria-label="Close inspector">
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
       </div>
 
       <div className="px-5 py-4 space-y-4 overflow-y-auto">
@@ -398,6 +404,7 @@ export default function TraceDetailPage() {
   const [events, setEvents] = useState<SpanEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedSpan, setSelectedSpan] = useState<Span | null>(null);
+  const [fixContext, setFixContext] = useState<FixContext | null>(null);
   const inspectorRef = useRef<HTMLDivElement | null>(null);
 
   // Close the inspector with Escape.
@@ -579,11 +586,27 @@ export default function TraceDetailPage() {
 
           {selectedSpan && (
             <div ref={inspectorRef} className="lg:sticky lg:top-4 lg:self-start lg:max-h-[calc(100vh-2rem)]">
-              <SpanInspector span={selectedSpan} onClose={() => setSelectedSpan(null)} />
+              <SpanInspector
+                span={selectedSpan}
+                onClose={() => setSelectedSpan(null)}
+                onFix={() =>
+                  setFixContext({
+                    traceId: trace.id,
+                    spanId: selectedSpan.id,
+                    projectId: (parseJson(trace.metadata) as { projectId?: string } | null)?.projectId ?? null,
+                  })
+                }
+              />
             </div>
           )}
         </div>
       </div>
+
+      <FixDialog
+        open={!!fixContext}
+        context={fixContext}
+        onClose={() => setFixContext(null)}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/Fix/BisectBanner.tsx
+++ b/apps/web/src/components/Fix/BisectBanner.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Link from "next/link";
+
+interface BisectBannerProps {
+  regressionSha: string;
+  parentSha?: string;
+}
+
+export function BisectBanner({ regressionSha, parentSha }: BisectBannerProps) {
+  const short = regressionSha.slice(0, 7);
+  return (
+    <div className="bg-orange-500/10 border border-orange-500/30 rounded-lg p-3 flex items-start gap-3">
+      <svg className="w-4 h-4 text-orange-400 mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+      </svg>
+      <div className="text-sm text-orange-200 space-y-1">
+        <p>
+          Regression introduced in <code className="bg-orange-500/15 text-orange-100 px-1.5 py-0.5 rounded font-mono text-xs">{short}</code>.
+          Fix proposed against that commit.
+        </p>
+        {parentSha && (
+          <p className="text-xs text-orange-300/80">
+            Last known good: <code className="font-mono">{parentSha.slice(0, 7)}</code>
+          </p>
+        )}
+        <p className="text-xs">
+          <Link href={`/commits?sha=${regressionSha}`} className="underline hover:text-orange-100">
+            View traces on this commit
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Fix/DiffActions.tsx
+++ b/apps/web/src/components/Fix/DiffActions.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { COLLECTOR_URL } from "../../lib/api";
+
+interface DiffActionsProps {
+  diff: string;
+  /** Null when the run used a git source — apply is path-mode only. */
+  sourceDir: string | null;
+  traceId: string;
+}
+
+type ApplyState = { kind: "idle" } | { kind: "applying" } | { kind: "applied" } | { kind: "error"; message: string };
+
+export function DiffActions({ diff, sourceDir, traceId }: DiffActionsProps) {
+  const [state, setState] = useState<ApplyState>({ kind: "idle" });
+
+  const applyToTree = async (): Promise<void> => {
+    if (!sourceDir) return;
+    setState({ kind: "applying" });
+    try {
+      const res = await fetch(`${COLLECTOR_URL}/v1/fix-apply`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sourceDir, diff }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: { message?: string; detail?: string } };
+        setState({ kind: "error", message: body.error?.detail ?? body.error?.message ?? `apply failed: ${res.status}` });
+        return;
+      }
+      setState({ kind: "applied" });
+    } catch (err) {
+      setState({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-2 flex-wrap">
+      <div className="flex items-center gap-2">
+        {sourceDir && (
+          <button
+            type="button"
+            disabled={state.kind === "applying"}
+            onClick={() => void applyToTree()}
+            className="px-3 py-1.5 rounded text-xs font-medium bg-emerald-500/15 text-emerald-300 border border-emerald-500/30 hover:bg-emerald-500/25 disabled:opacity-50"
+            title={`git apply the diff inside ${sourceDir}`}
+          >
+            {state.kind === "applying"
+              ? "Applying…"
+              : state.kind === "applied"
+                ? "Applied ✓"
+                : "Apply to working tree"}
+          </button>
+        )}
+      </div>
+      <div className="text-xs text-zinc-500 font-mono truncate" title={`trace ${traceId}`}>
+        {sourceDir ?? "git source — apply via CLI"}
+      </div>
+      {state.kind === "error" && (
+        <div className="w-full bg-red-950/40 border border-red-900 rounded px-2 py-1 text-[11px] text-red-300 font-mono whitespace-pre-wrap">
+          {state.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/Fix/DiffActions.tsx
+++ b/apps/web/src/components/Fix/DiffActions.tsx
@@ -12,8 +12,21 @@ interface DiffActionsProps {
 
 type ApplyState = { kind: "idle" } | { kind: "applying" } | { kind: "applied" } | { kind: "error"; message: string };
 
+function downloadDiff(diff: string, traceId: string): void {
+  const blob = new Blob([diff], { type: "text/x-diff" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `pathlight-fix-${traceId.slice(0, 12)}.patch`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
 export function DiffActions({ diff, sourceDir, traceId }: DiffActionsProps) {
   const [state, setState] = useState<ApplyState>({ kind: "idle" });
+  const [copied, setCopied] = useState(false);
 
   const applyToTree = async (): Promise<void> => {
     if (!sourceDir) return;
@@ -35,13 +48,25 @@ export function DiffActions({ diff, sourceDir, traceId }: DiffActionsProps) {
     }
   };
 
+  const copyToClipboard = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(diff);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const disabled = diff.trim().length === 0;
+
   return (
     <div className="flex items-center justify-between gap-2 flex-wrap">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 flex-wrap">
         {sourceDir && (
           <button
             type="button"
-            disabled={state.kind === "applying"}
+            disabled={disabled || state.kind === "applying"}
             onClick={() => void applyToTree()}
             className="px-3 py-1.5 rounded text-xs font-medium bg-emerald-500/15 text-emerald-300 border border-emerald-500/30 hover:bg-emerald-500/25 disabled:opacity-50"
             title={`git apply the diff inside ${sourceDir}`}
@@ -53,6 +78,22 @@ export function DiffActions({ diff, sourceDir, traceId }: DiffActionsProps) {
                 : "Apply to working tree"}
           </button>
         )}
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => downloadDiff(diff, traceId)}
+          className="px-3 py-1.5 rounded text-xs font-medium bg-zinc-800 text-zinc-200 border border-zinc-700 hover:bg-zinc-700 disabled:opacity-50"
+        >
+          Download .patch
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => void copyToClipboard()}
+          className="px-3 py-1.5 rounded text-xs font-medium bg-zinc-800 text-zinc-200 border border-zinc-700 hover:bg-zinc-700 disabled:opacity-50"
+        >
+          {copied ? "Copied ✓" : "Copy"}
+        </button>
       </div>
       <div className="text-xs text-zinc-500 font-mono truncate" title={`trace ${traceId}`}>
         {sourceDir ?? "git source — apply via CLI"}

--- a/apps/web/src/components/Fix/DiffPreview.tsx
+++ b/apps/web/src/components/Fix/DiffPreview.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+/**
+ * Unified-diff viewer. Rolls our own instead of pulling
+ * react-diff-viewer-continued (~50KB gz) because (1) we don't need
+ * side-by-side alignment for v1 — unified view with color-coded lines
+ * communicates the change clearly at ~5KB — and (2) avoids pinning a
+ * third-party rendering library's color palette / accessibility story
+ * before we've seen real usage.
+ */
+
+interface ParsedFile {
+  header: string;
+  oldPath: string;
+  newPath: string;
+  hunks: ParsedHunk[];
+}
+
+interface ParsedHunk {
+  header: string;
+  lines: ParsedLine[];
+}
+
+interface ParsedLine {
+  kind: "add" | "remove" | "context" | "meta";
+  text: string;
+}
+
+export function DiffPreview({ diff }: { diff: string }) {
+  const files = useMemo(() => parseUnifiedDiff(diff), [diff]);
+
+  if (files.length === 0) {
+    return (
+      <div className="bg-zinc-950 border border-zinc-800 rounded-lg p-4 text-sm text-zinc-500">
+        Engine returned an empty diff. See the explanation above for what additional context is needed.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {files.map((file, i) => (
+        <FilePanel key={i} file={file} />
+      ))}
+    </div>
+  );
+}
+
+function FilePanel({ file }: { file: ParsedFile }) {
+  const [expanded, setExpanded] = useState(true);
+  const addCount = file.hunks.reduce((n, h) => n + h.lines.filter((l) => l.kind === "add").length, 0);
+  const removeCount = file.hunks.reduce((n, h) => n + h.lines.filter((l) => l.kind === "remove").length, 0);
+
+  return (
+    <div className="bg-zinc-950 border border-zinc-800 rounded-lg overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full px-3 py-2 border-b border-zinc-800 flex items-center gap-3 text-left hover:bg-zinc-900"
+      >
+        <svg
+          className={`w-3 h-3 text-zinc-500 transition-transform ${expanded ? "rotate-90" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+        <code className="font-mono text-xs text-zinc-300 truncate">
+          {file.newPath === "/dev/null" ? file.oldPath : file.newPath}
+        </code>
+        <span className="ml-auto text-xs font-mono flex items-center gap-2 shrink-0">
+          <span className="text-emerald-400">+{addCount}</span>
+          <span className="text-red-400">-{removeCount}</span>
+        </span>
+      </button>
+      {expanded && (
+        <div className="overflow-x-auto">
+          <table className="w-full font-mono text-[11px]">
+            <tbody>
+              {file.hunks.flatMap((hunk, hi) => [
+                <tr key={`h-${hi}`} className="bg-blue-900/15">
+                  <td className="px-3 py-0.5 text-blue-300 whitespace-pre">{hunk.header}</td>
+                </tr>,
+                ...hunk.lines.map((line, li) => (
+                  <tr key={`l-${hi}-${li}`} className={lineBg(line.kind)}>
+                    <td className={`px-3 py-0.5 whitespace-pre ${lineText(line.kind)}`}>
+                      {line.text}
+                    </td>
+                  </tr>
+                )),
+              ])}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function lineBg(kind: ParsedLine["kind"]): string {
+  switch (kind) {
+    case "add":
+      return "bg-emerald-900/20";
+    case "remove":
+      return "bg-red-900/20";
+    case "meta":
+      return "bg-zinc-900/60";
+    default:
+      return "";
+  }
+}
+
+function lineText(kind: ParsedLine["kind"]): string {
+  switch (kind) {
+    case "add":
+      return "text-emerald-300";
+    case "remove":
+      return "text-red-300";
+    case "meta":
+      return "text-zinc-500";
+    default:
+      return "text-zinc-300";
+  }
+}
+
+function parseUnifiedDiff(diff: string): ParsedFile[] {
+  const files: ParsedFile[] = [];
+  const lines = diff.split("\n");
+  let i = 0;
+
+  while (i < lines.length) {
+    // Skip anything before the first diff header.
+    if (!lines[i].startsWith("diff --git") && !lines[i].startsWith("--- ")) {
+      i++;
+      continue;
+    }
+
+    const header = lines[i];
+    let oldPath = "";
+    let newPath = "";
+
+    // Accept both "diff --git a/x b/y\n--- a/x\n+++ b/y" and bare "--- a/x\n+++ b/y".
+    if (lines[i].startsWith("diff --git")) i++;
+    // Skip index/mode lines.
+    while (i < lines.length && !lines[i].startsWith("--- ") && !lines[i].startsWith("@@")) {
+      i++;
+    }
+    if (i < lines.length && lines[i].startsWith("--- ")) {
+      oldPath = lines[i].slice(4).replace(/^a\//, "");
+      i++;
+    }
+    if (i < lines.length && lines[i].startsWith("+++ ")) {
+      newPath = lines[i].slice(4).replace(/^b\//, "");
+      i++;
+    }
+
+    const hunks: ParsedHunk[] = [];
+    while (i < lines.length && lines[i].startsWith("@@")) {
+      const hunkHeader = lines[i];
+      i++;
+      const hunkLines: ParsedLine[] = [];
+      while (
+        i < lines.length &&
+        !lines[i].startsWith("@@") &&
+        !lines[i].startsWith("diff --git") &&
+        !lines[i].startsWith("--- ")
+      ) {
+        const text = lines[i];
+        if (text.startsWith("+")) hunkLines.push({ kind: "add", text });
+        else if (text.startsWith("-")) hunkLines.push({ kind: "remove", text });
+        else if (text.startsWith("\\")) hunkLines.push({ kind: "meta", text });
+        else hunkLines.push({ kind: "context", text });
+        i++;
+      }
+      hunks.push({ header: hunkHeader, lines: hunkLines });
+    }
+
+    if (oldPath || newPath || hunks.length > 0) {
+      files.push({ header, oldPath, newPath: newPath || oldPath, hunks });
+    }
+  }
+
+  return files;
+}

--- a/apps/web/src/components/Fix/FixButton.tsx
+++ b/apps/web/src/components/Fix/FixButton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import type { MouseEventHandler } from "react";
+
+interface FixButtonProps {
+  visible: boolean;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+}
+
+export function FixButton({ visible, onClick }: FixButtonProps) {
+  if (!visible) return null;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium bg-orange-500/15 text-orange-300 border border-orange-500/30 hover:bg-orange-500/25 hover:border-orange-500/50 transition-colors"
+      title="Propose a fix via the Pathlight fix engine"
+    >
+      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z" />
+      </svg>
+      Fix this
+    </button>
+  );
+}

--- a/apps/web/src/components/Fix/FixDialog.tsx
+++ b/apps/web/src/components/Fix/FixDialog.tsx
@@ -5,6 +5,7 @@ import { FixForm, type FixFormValue } from "./FixForm";
 import { FixStream, type FixResultPayload } from "./FixStream";
 import { DiffPreview } from "./DiffPreview";
 import { DiffActions } from "./DiffActions";
+import { BisectBanner } from "./BisectBanner";
 
 export interface FixContext {
   traceId: string;
@@ -98,6 +99,12 @@ export function FixDialog({ open, context, onClose }: FixDialogProps) {
 
           {phase.kind === "done" && (
             <div className="space-y-3">
+              {phase.result.regressionSha && (
+                <BisectBanner
+                  regressionSha={phase.result.regressionSha}
+                  parentSha={phase.result.parentSha}
+                />
+              )}
               <div className="bg-zinc-950 border border-zinc-800 rounded-lg p-4 space-y-2">
                 <p className="text-[10px] text-zinc-600 uppercase tracking-widest">Explanation</p>
                 <p className="text-sm text-zinc-300">{phase.result.explanation}</p>
@@ -108,9 +115,6 @@ export function FixDialog({ open, context, onClose }: FixDialogProps) {
                 sourceDir={phase.form.source.kind === "path" ? phase.form.source.dir : null}
                 traceId={context.traceId}
               />
-              <p className="text-xs text-zinc-600">
-                Download / copy in T7 · bisect banner in T8.
-              </p>
             </div>
           )}
         </div>

--- a/apps/web/src/components/Fix/FixDialog.tsx
+++ b/apps/web/src/components/Fix/FixDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { FixForm, type FixFormValue } from "./FixForm";
 import { FixStream, type FixResultPayload } from "./FixStream";
 import { DiffPreview } from "./DiffPreview";
+import { DiffActions } from "./DiffActions";
 
 export interface FixContext {
   traceId: string;
@@ -102,8 +103,13 @@ export function FixDialog({ open, context, onClose }: FixDialogProps) {
                 <p className="text-sm text-zinc-300">{phase.result.explanation}</p>
               </div>
               <DiffPreview diff={phase.result.diff} />
+              <DiffActions
+                diff={phase.result.diff}
+                sourceDir={phase.form.source.kind === "path" ? phase.form.source.dir : null}
+                traceId={context.traceId}
+              />
               <p className="text-xs text-zinc-600">
-                Apply to working tree in T6 · download/copy in T7 · bisect banner in T8.
+                Download / copy in T7 · bisect banner in T8.
               </p>
             </div>
           )}

--- a/apps/web/src/components/Fix/FixDialog.tsx
+++ b/apps/web/src/components/Fix/FixDialog.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { FixForm, type FixFormValue } from "./FixForm";
 import { FixStream, type FixResultPayload } from "./FixStream";
+import { DiffPreview } from "./DiffPreview";
 
 export interface FixContext {
   traceId: string;
@@ -95,14 +96,14 @@ export function FixDialog({ open, context, onClose }: FixDialogProps) {
           )}
 
           {phase.kind === "done" && (
-            <div className="bg-zinc-950 border border-zinc-800 rounded-lg p-4 space-y-2">
-              <p className="text-[10px] text-zinc-600 uppercase tracking-widest">Result</p>
-              <p className="text-sm text-zinc-300">{phase.result.explanation}</p>
-              <p className="text-xs text-zinc-500">
-                Files changed: {phase.result.filesChanged.length > 0 ? phase.result.filesChanged.join(", ") : "none"}
-              </p>
+            <div className="space-y-3">
+              <div className="bg-zinc-950 border border-zinc-800 rounded-lg p-4 space-y-2">
+                <p className="text-[10px] text-zinc-600 uppercase tracking-widest">Explanation</p>
+                <p className="text-sm text-zinc-300">{phase.result.explanation}</p>
+              </div>
+              <DiffPreview diff={phase.result.diff} />
               <p className="text-xs text-zinc-600">
-                Diff preview lands in T5 · download/copy in T7 · apply in T6.
+                Apply to working tree in T6 · download/copy in T7 · bisect banner in T8.
               </p>
             </div>
           )}

--- a/apps/web/src/components/Fix/FixDialog.tsx
+++ b/apps/web/src/components/Fix/FixDialog.tsx
@@ -2,12 +2,19 @@
 
 import { useEffect, useState } from "react";
 import { FixForm, type FixFormValue } from "./FixForm";
+import { FixStream, type FixResultPayload } from "./FixStream";
 
 export interface FixContext {
   traceId: string;
   spanId?: string;
   projectId: string | null;
 }
+
+type Phase =
+  | { kind: "idle" }
+  | { kind: "streaming"; form: FixFormValue }
+  | { kind: "done"; form: FixFormValue; result: FixResultPayload }
+  | { kind: "error"; form: FixFormValue; message: string };
 
 interface FixDialogProps {
   open: boolean;
@@ -16,8 +23,8 @@ interface FixDialogProps {
 }
 
 export function FixDialog({ open, context, onClose }: FixDialogProps) {
-  const [submitting, setSubmitting] = useState(false);
-  const [lastSubmitted, setLastSubmitted] = useState<FixFormValue | null>(null);
+  const [phase, setPhase] = useState<Phase>({ kind: "idle" });
+  const submitting = phase.kind === "streaming";
 
   useEffect(() => {
     if (!open) return;
@@ -29,19 +36,13 @@ export function FixDialog({ open, context, onClose }: FixDialogProps) {
   }, [open, onClose, submitting]);
 
   useEffect(() => {
-    if (!open) {
-      setSubmitting(false);
-      setLastSubmitted(null);
-    }
+    if (!open) setPhase({ kind: "idle" });
   }, [open]);
 
   if (!open || !context) return null;
 
-  const handleSubmit = (value: FixFormValue): void => {
-    // T4 wires the SSE stream here. For now the form flows to a captured
-    // payload display so T3's key picker can be developed against a real form.
-    setLastSubmitted(value);
-    setSubmitting(false);
+  const handleSubmit = (form: FixFormValue): void => {
+    setPhase({ kind: "streaming", form });
   };
 
   return (
@@ -70,20 +71,39 @@ export function FixDialog({ open, context, onClose }: FixDialogProps) {
             </svg>
           </button>
         </div>
-        <div className="px-5 py-5 overflow-y-auto">
+        <div className="px-5 py-5 space-y-5 overflow-y-auto">
           <FixForm
             projectId={context.projectId}
             submitting={submitting}
             onSubmit={handleSubmit}
           />
-          {lastSubmitted && (
-            <div className="mt-5 bg-zinc-950 border border-zinc-800 rounded-lg p-3">
-              <p className="text-[10px] text-zinc-600 uppercase tracking-widest mb-2">
-                Captured payload (T4 streams this to /v1/fix)
+
+          {phase.kind === "streaming" && context.projectId && (
+            <FixStream
+              projectId={context.projectId}
+              traceId={context.traceId}
+              form={phase.form}
+              onResult={(result) => setPhase({ kind: "done", form: phase.form, result })}
+              onFail={(message) => setPhase({ kind: "error", form: phase.form, message })}
+            />
+          )}
+
+          {phase.kind === "error" && (
+            <div className="bg-red-950/40 border border-red-900 rounded-lg p-3 text-sm text-red-300">
+              {phase.message}
+            </div>
+          )}
+
+          {phase.kind === "done" && (
+            <div className="bg-zinc-950 border border-zinc-800 rounded-lg p-4 space-y-2">
+              <p className="text-[10px] text-zinc-600 uppercase tracking-widest">Result</p>
+              <p className="text-sm text-zinc-300">{phase.result.explanation}</p>
+              <p className="text-xs text-zinc-500">
+                Files changed: {phase.result.filesChanged.length > 0 ? phase.result.filesChanged.join(", ") : "none"}
               </p>
-              <pre className="text-[11px] text-zinc-400 font-mono whitespace-pre-wrap">
-                {JSON.stringify(lastSubmitted, null, 2)}
-              </pre>
+              <p className="text-xs text-zinc-600">
+                Diff preview lands in T5 · download/copy in T7 · apply in T6.
+              </p>
             </div>
           )}
         </div>

--- a/apps/web/src/components/Fix/FixDialog.tsx
+++ b/apps/web/src/components/Fix/FixDialog.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+
+export interface FixContext {
+  traceId: string;
+  spanId?: string;
+  projectId: string | null;
+}
+
+interface FixDialogProps {
+  open: boolean;
+  context: FixContext | null;
+  onClose: () => void;
+}
+
+export function FixDialog({ open, context, onClose }: FixDialogProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open || !context) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Propose a fix"
+        className="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col"
+      >
+        <div className="border-b border-zinc-800 px-5 py-3 flex items-center gap-3">
+          <h2 className="font-semibold">Propose a fix</h2>
+          <span className="text-xs text-zinc-500 font-mono truncate">
+            trace {context.traceId.slice(0, 12)}
+            {context.spanId ? ` · span ${context.spanId.slice(0, 8)}` : ""}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-auto text-zinc-500 hover:text-zinc-300 shrink-0"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="px-5 py-6 space-y-3 overflow-y-auto">
+          <p className="text-sm text-zinc-400">
+            Fix form lands in T2. Key picker in T3. SSE stream in T4. Diff preview in T5.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Fix/FixDialog.tsx
+++ b/apps/web/src/components/Fix/FixDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { FixForm, type FixFormValue } from "./FixForm";
 
 export interface FixContext {
   traceId: string;
@@ -15,16 +16,33 @@ interface FixDialogProps {
 }
 
 export function FixDialog({ open, context, onClose }: FixDialogProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [lastSubmitted, setLastSubmitted] = useState<FixFormValue | null>(null);
+
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent): void => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape" && !submitting) onClose();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+  }, [open, onClose, submitting]);
+
+  useEffect(() => {
+    if (!open) {
+      setSubmitting(false);
+      setLastSubmitted(null);
+    }
+  }, [open]);
 
   if (!open || !context) return null;
+
+  const handleSubmit = (value: FixFormValue): void => {
+    // T4 wires the SSE stream here. For now the form flows to a captured
+    // payload display so T3's key picker can be developed against a real form.
+    setLastSubmitted(value);
+    setSubmitting(false);
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
@@ -43,7 +61,8 @@ export function FixDialog({ open, context, onClose }: FixDialogProps) {
           <button
             type="button"
             onClick={onClose}
-            className="ml-auto text-zinc-500 hover:text-zinc-300 shrink-0"
+            disabled={submitting}
+            className="ml-auto text-zinc-500 hover:text-zinc-300 shrink-0 disabled:opacity-50"
             aria-label="Close"
           >
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -51,10 +70,22 @@ export function FixDialog({ open, context, onClose }: FixDialogProps) {
             </svg>
           </button>
         </div>
-        <div className="px-5 py-6 space-y-3 overflow-y-auto">
-          <p className="text-sm text-zinc-400">
-            Fix form lands in T2. Key picker in T3. SSE stream in T4. Diff preview in T5.
-          </p>
+        <div className="px-5 py-5 overflow-y-auto">
+          <FixForm
+            projectId={context.projectId}
+            submitting={submitting}
+            onSubmit={handleSubmit}
+          />
+          {lastSubmitted && (
+            <div className="mt-5 bg-zinc-950 border border-zinc-800 rounded-lg p-3">
+              <p className="text-[10px] text-zinc-600 uppercase tracking-widest mb-2">
+                Captured payload (T4 streams this to /v1/fix)
+              </p>
+              <pre className="text-[11px] text-zinc-400 font-mono whitespace-pre-wrap">
+                {JSON.stringify(lastSubmitted, null, 2)}
+              </pre>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/Fix/FixForm.tsx
+++ b/apps/web/src/components/Fix/FixForm.tsx
@@ -2,6 +2,7 @@
 
 import type { FormEvent } from "react";
 import { useMemo, useState } from "react";
+import { KeyPicker } from "./KeyPicker";
 
 export type SourceMode = "path" | "git";
 export type FixMode = "span" | "trace" | "bisect";
@@ -128,15 +129,24 @@ export function FixForm({ projectId, submitting, onSubmit }: FixFormProps) {
                 required
               />
             </Field>
-            <Field label="Git token (keyId from /settings/keys)">
-              <input
-                type="text"
-                value={gitTokenId}
-                onChange={(e) => setGitTokenId(e.target.value)}
-                placeholder="key_xxx"
-                className={inputClass}
-                required
-              />
+            <Field label="Git token">
+              {projectId ? (
+                <KeyPicker
+                  projectId={projectId}
+                  kind="git"
+                  value={gitTokenId}
+                  onChange={setGitTokenId}
+                />
+              ) : (
+                <input
+                  type="text"
+                  value={gitTokenId}
+                  onChange={(e) => setGitTokenId(e.target.value)}
+                  placeholder="key_xxx"
+                  className={inputClass}
+                  required
+                />
+              )}
             </Field>
             <Field label="Ref (optional, defaults to HEAD)">
               <input
@@ -161,18 +171,25 @@ export function FixForm({ projectId, submitting, onSubmit }: FixFormProps) {
             { value: "openai", label: "OpenAI" },
           ]}
         />
-        <Field label="API key (keyId from /settings/keys)">
-          <input
-            type="text"
-            value={llmKeyId}
-            onChange={(e) => setLlmKeyId(e.target.value)}
-            placeholder="key_xxx"
-            className={inputClass}
-            required
-          />
-          <p className="text-[11px] text-zinc-500 mt-1">
-            T3 replaces this with a live picker sourced from /v1/projects/&lt;id&gt;/keys.
-          </p>
+        <Field label="API key">
+          {projectId ? (
+            <KeyPicker
+              projectId={projectId}
+              kind="llm"
+              provider={provider}
+              value={llmKeyId}
+              onChange={setLlmKeyId}
+            />
+          ) : (
+            <input
+              type="text"
+              value={llmKeyId}
+              onChange={(e) => setLlmKeyId(e.target.value)}
+              placeholder="key_xxx"
+              className={inputClass}
+              required
+            />
+          )}
         </Field>
         <Field label="Model (optional)">
           <input

--- a/apps/web/src/components/Fix/FixForm.tsx
+++ b/apps/web/src/components/Fix/FixForm.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useMemo, useState } from "react";
+
+export type SourceMode = "path" | "git";
+export type FixMode = "span" | "trace" | "bisect";
+export type LlmProvider = "anthropic" | "openai";
+
+export interface FixFormValue {
+  source:
+    | { kind: "path"; dir: string }
+    | { kind: "git"; repoUrl: string; tokenId: string; ref: string };
+  llm: {
+    provider: LlmProvider;
+    keyId: string;
+    model?: string;
+  };
+  mode:
+    | { kind: "span" }
+    | { kind: "trace" }
+    | { kind: "bisect"; from: string; to: string };
+}
+
+interface FixFormProps {
+  projectId: string | null;
+  submitting: boolean;
+  onSubmit: (value: FixFormValue) => void;
+}
+
+export function FixForm({ projectId, submitting, onSubmit }: FixFormProps) {
+  const [sourceMode, setSourceMode] = useState<SourceMode>("path");
+  const [sourceDir, setSourceDir] = useState("");
+  const [repoUrl, setRepoUrl] = useState("");
+  const [gitTokenId, setGitTokenId] = useState("");
+  const [ref, setRef] = useState("");
+
+  const [provider, setProvider] = useState<LlmProvider>("anthropic");
+  const [llmKeyId, setLlmKeyId] = useState("");
+  const [model, setModel] = useState("");
+
+  const [mode, setMode] = useState<FixMode>("span");
+  const [fromSha, setFromSha] = useState("");
+  const [toSha, setToSha] = useState("");
+
+  const sourceValid = useMemo(() => {
+    if (sourceMode === "path") return sourceDir.trim().length > 0;
+    return repoUrl.trim().length > 0 && gitTokenId.trim().length > 0;
+  }, [sourceMode, sourceDir, repoUrl, gitTokenId]);
+
+  const modeValid = useMemo(() => {
+    if (mode === "bisect") {
+      if (sourceMode !== "git") return false;
+      return fromSha.trim().length > 0 && toSha.trim().length > 0;
+    }
+    return true;
+  }, [mode, sourceMode, fromSha, toSha]);
+
+  const llmValid = llmKeyId.trim().length > 0;
+  const projectValid = projectId !== null && projectId.length > 0;
+  const canSubmit = sourceValid && modeValid && llmValid && projectValid && !submitting;
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>): void => {
+    e.preventDefault();
+    if (!canSubmit) return;
+
+    const value: FixFormValue = {
+      source:
+        sourceMode === "path"
+          ? { kind: "path", dir: sourceDir.trim() }
+          : {
+              kind: "git",
+              repoUrl: repoUrl.trim(),
+              tokenId: gitTokenId.trim(),
+              ref: ref.trim(),
+            },
+      llm: {
+        provider,
+        keyId: llmKeyId.trim(),
+        model: model.trim() || undefined,
+      },
+      mode:
+        mode === "bisect"
+          ? { kind: "bisect", from: fromSha.trim(), to: toSha.trim() }
+          : { kind: mode },
+    };
+    onSubmit(value);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {!projectValid && (
+        <div className="bg-amber-900/20 border border-amber-800/50 rounded-lg p-3 text-xs text-amber-300">
+          This trace has no projectId. BYOK keys are scoped per project, so the fix engine can&apos;t resolve a key here yet.
+        </div>
+      )}
+
+      <Section label="Source">
+        <RadioGroup
+          name="source-mode"
+          value={sourceMode}
+          onChange={(v) => setSourceMode(v as SourceMode)}
+          options={[
+            { value: "path", label: "Local path" },
+            { value: "git", label: "Git (clone + read-only)" },
+          ]}
+        />
+        {sourceMode === "path" ? (
+          <Field label="Source dir">
+            <input
+              type="text"
+              value={sourceDir}
+              onChange={(e) => setSourceDir(e.target.value)}
+              placeholder="/abs/path/to/repo"
+              className={inputClass}
+              required
+            />
+          </Field>
+        ) : (
+          <div className="space-y-2">
+            <Field label="Repo URL">
+              <input
+                type="url"
+                value={repoUrl}
+                onChange={(e) => setRepoUrl(e.target.value)}
+                placeholder="https://github.com/owner/repo.git"
+                className={inputClass}
+                required
+              />
+            </Field>
+            <Field label="Git token (keyId from /settings/keys)">
+              <input
+                type="text"
+                value={gitTokenId}
+                onChange={(e) => setGitTokenId(e.target.value)}
+                placeholder="key_xxx"
+                className={inputClass}
+                required
+              />
+            </Field>
+            <Field label="Ref (optional, defaults to HEAD)">
+              <input
+                type="text"
+                value={ref}
+                onChange={(e) => setRef(e.target.value)}
+                placeholder="main"
+                className={inputClass}
+              />
+            </Field>
+          </div>
+        )}
+      </Section>
+
+      <Section label="LLM">
+        <RadioGroup
+          name="provider"
+          value={provider}
+          onChange={(v) => setProvider(v as LlmProvider)}
+          options={[
+            { value: "anthropic", label: "Anthropic" },
+            { value: "openai", label: "OpenAI" },
+          ]}
+        />
+        <Field label="API key (keyId from /settings/keys)">
+          <input
+            type="text"
+            value={llmKeyId}
+            onChange={(e) => setLlmKeyId(e.target.value)}
+            placeholder="key_xxx"
+            className={inputClass}
+            required
+          />
+          <p className="text-[11px] text-zinc-500 mt-1">
+            T3 replaces this with a live picker sourced from /v1/projects/&lt;id&gt;/keys.
+          </p>
+        </Field>
+        <Field label="Model (optional)">
+          <input
+            type="text"
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            placeholder={provider === "anthropic" ? "claude-opus-4-7" : "gpt-5.4"}
+            className={inputClass}
+          />
+        </Field>
+      </Section>
+
+      <Section label="Mode">
+        <RadioGroup
+          name="mode"
+          value={mode}
+          onChange={(v) => setMode(v as FixMode)}
+          options={[
+            { value: "span", label: "This span" },
+            { value: "trace", label: "Whole trace" },
+            { value: "bisect", label: "Bisect", disabled: sourceMode !== "git" },
+          ]}
+        />
+        {mode === "bisect" && sourceMode !== "git" && (
+          <p className="text-xs text-amber-300">
+            Bisect requires a git source — switch Source to &quot;Git&quot; above.
+          </p>
+        )}
+        {mode === "bisect" && sourceMode === "git" && (
+          <div className="grid grid-cols-2 gap-2">
+            <Field label="From (known-good SHA)">
+              <input
+                type="text"
+                value={fromSha}
+                onChange={(e) => setFromSha(e.target.value)}
+                placeholder="abc123"
+                className={`${inputClass} font-mono`}
+                required
+              />
+            </Field>
+            <Field label="To (known-bad SHA)">
+              <input
+                type="text"
+                value={toSha}
+                onChange={(e) => setToSha(e.target.value)}
+                placeholder="def456"
+                className={`${inputClass} font-mono`}
+                required
+              />
+            </Field>
+          </div>
+        )}
+      </Section>
+
+      <div className="pt-2 flex justify-end">
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="px-4 py-2 rounded text-sm font-medium bg-orange-500/20 text-orange-200 border border-orange-500/40 hover:bg-orange-500/30 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {submitting ? "Streaming…" : "Propose fix"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+const inputClass =
+  "w-full bg-zinc-950 border border-zinc-800 rounded px-3 py-2 text-sm focus:outline-none focus:border-zinc-600";
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-2">
+      <p className="text-[10px] text-zinc-600 uppercase tracking-widest">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block text-xs text-zinc-400 space-y-1">
+      <span>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+interface RadioGroupProps<T extends string> {
+  name: string;
+  value: T;
+  onChange: (v: T) => void;
+  options: { value: T; label: string; disabled?: boolean }[];
+}
+function RadioGroup<T extends string>({ name, value, onChange, options }: RadioGroupProps<T>) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((opt) => (
+        <label
+          key={opt.value}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded text-xs border cursor-pointer ${
+            value === opt.value
+              ? "bg-zinc-800 border-zinc-600 text-zinc-100"
+              : "bg-zinc-950 border-zinc-800 text-zinc-400 hover:border-zinc-700"
+          } ${opt.disabled ? "opacity-40 cursor-not-allowed" : ""}`}
+        >
+          <input
+            type="radio"
+            name={name}
+            value={opt.value}
+            checked={value === opt.value}
+            disabled={opt.disabled}
+            onChange={() => !opt.disabled && onChange(opt.value)}
+            className="sr-only"
+          />
+          {opt.label}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/Fix/FixStream.tsx
+++ b/apps/web/src/components/Fix/FixStream.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { COLLECTOR_URL } from "../../lib/api";
+import { openSSE, type SSEEvent } from "../../lib/sse";
+import type { FixFormValue } from "./FixForm";
+
+export interface FixResultPayload {
+  diff: string;
+  explanation: string;
+  filesChanged: string[];
+  metaTraceId?: string;
+  regressionSha?: string;
+  parentSha?: string;
+}
+
+interface FixStreamProps {
+  projectId: string;
+  traceId: string;
+  form: FixFormValue;
+  onResult: (result: FixResultPayload) => void;
+  onFail: (message: string) => void;
+}
+
+interface ProgressEntry {
+  id: number;
+  text: string;
+}
+
+export function FixStream({ projectId, traceId, form, onResult, onFail }: FixStreamProps) {
+  const [progress, setProgress] = useState<ProgressEntry[]>([]);
+  const [closed, setClosed] = useState(false);
+  const idRef = useRef(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const pushProgress = (text: string): void => {
+      idRef.current += 1;
+      const entry = { id: idRef.current, text };
+      setProgress((prev) => [...prev, entry]);
+    };
+
+    const body = {
+      traceId,
+      projectId,
+      source: form.source,
+      llm: form.llm,
+      mode: form.mode.kind,
+      ...(form.mode.kind === "bisect" ? { from: form.mode.from, to: form.mode.to } : {}),
+    };
+
+    void openSSE({
+      url: `${COLLECTOR_URL}/v1/fix`,
+      body,
+      signal: controller.signal,
+      onEvent: (event: SSEEvent) => {
+        switch (event.event) {
+          case "progress": {
+            pushProgress(progressLine(safeJson(event.data)));
+            return;
+          }
+          case "chunk": {
+            pushProgress("received partial chunk");
+            return;
+          }
+          case "result": {
+            const parsed = safeJson(event.data) as FixResultPayload;
+            onResult(parsed);
+            return;
+          }
+          case "error": {
+            const parsed = safeJson(event.data) as { message?: string };
+            onFail(parsed?.message ?? "Fix engine failed");
+            return;
+          }
+          case "done": {
+            setClosed(true);
+            return;
+          }
+        }
+      },
+      onError: (err) => {
+        onFail(err instanceof Error ? err.message : "Connection error");
+      },
+      onClose: () => setClosed(true),
+    });
+
+    return () => controller.abort();
+  }, [projectId, traceId, form, onResult, onFail]);
+
+  return (
+    <div className="bg-zinc-950 border border-zinc-800 rounded-lg">
+      <div className="px-3 py-2 border-b border-zinc-800 flex items-center gap-2">
+        <div className={`w-1.5 h-1.5 rounded-full ${closed ? "bg-zinc-600" : "bg-blue-500 animate-pulse"}`} />
+        <span className="text-xs text-zinc-400">
+          {closed ? "Stream closed" : "Streaming fix engine…"}
+        </span>
+      </div>
+      <div className="px-3 py-2 max-h-48 overflow-y-auto font-mono text-[11px] text-zinc-500 space-y-0.5">
+        {progress.length === 0 && !closed && (
+          <p className="text-zinc-600">Waiting for first event…</p>
+        )}
+        {progress.map((p) => (
+          <div key={p.id}>{p.text}</div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function progressLine(event: unknown): string {
+  if (!event || typeof event !== "object") return "progress";
+  const e = event as { kind?: string; fileCount?: number; provider?: string; model?: string; sha?: string; depth?: number };
+  switch (e.kind) {
+    case "fetching-trace":
+      return "# fetching trace";
+    case "reading-source":
+      return `# reading source (${e.fileCount ?? 0} file${e.fileCount === 1 ? "" : "s"})`;
+    case "calling-llm":
+      return `# calling ${e.provider ?? ""} ${e.model ?? ""}`.trim();
+    case "parsing-diff":
+      return "# parsing diff";
+    case "bisect-iteration":
+      return `# bisect depth ${e.depth ?? "?"} at ${(e.sha ?? "").slice(0, 7)}`;
+    case "bisect-found":
+      return `# regression found at ${(e.sha ?? "").slice(0, 7)}`;
+    default:
+      return `# ${e.kind ?? "progress"}`;
+  }
+}
+
+function safeJson(data: string): unknown {
+  try {
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/components/Fix/KeyPicker.tsx
+++ b/apps/web/src/components/Fix/KeyPicker.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { COLLECTOR_URL } from "../../lib/api";
+
+export interface ApiKeyOption {
+  id: string;
+  kind: "llm" | "git";
+  provider: string;
+  label: string;
+  preview: string;
+  lastUsedAt: string | null;
+}
+
+interface KeyPickerProps {
+  projectId: string;
+  kind: "llm" | "git";
+  /** Restrict to a single provider (e.g. "anthropic"). Omit to include all. */
+  provider?: string;
+  value: string;
+  onChange: (keyId: string) => void;
+}
+
+export function KeyPicker({ projectId, kind, provider, value, onChange }: KeyPickerProps) {
+  const [keys, setKeys] = useState<ApiKeyOption[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setKeys(null);
+    setError(null);
+    fetch(`${COLLECTOR_URL}/v1/projects/${encodeURIComponent(projectId)}/keys`)
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(res.status === 404 ? "Key store not enabled on this collector" : `fetch failed: ${res.status}`);
+        }
+        return (await res.json()) as { keys: ApiKeyOption[] };
+      })
+      .then((body) => {
+        if (cancelled) return;
+        setKeys(body.keys);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setKeys([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  const filtered = (keys ?? []).filter((k) => {
+    if (k.kind !== kind) return false;
+    if (provider && k.provider !== provider) return false;
+    return true;
+  });
+
+  if (keys === null) {
+    return <div className="text-xs text-zinc-500 px-2 py-1.5">Loading keys…</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-950/40 border border-red-900 rounded px-2 py-1.5 text-xs text-red-300">
+        {error}.{" "}
+        <Link href="/settings/keys" className="underline hover:text-red-200">
+          Manage keys
+        </Link>
+      </div>
+    );
+  }
+
+  if (filtered.length === 0) {
+    return (
+      <div className="bg-zinc-950 border border-zinc-800 rounded px-2 py-2 text-xs text-zinc-400">
+        No {kind === "llm" ? "LLM keys" : "git tokens"}
+        {provider ? ` for ${provider}` : ""} yet.{" "}
+        <Link href="/settings/keys" className="text-zinc-200 underline hover:text-white">
+          Add one
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full bg-zinc-950 border border-zinc-800 rounded px-3 py-2 text-sm focus:outline-none focus:border-zinc-600"
+    >
+      <option value="">Select a {kind === "llm" ? "key" : "token"}…</option>
+      {filtered.map((k) => (
+        <option key={k.id} value={k.id}>
+          {k.label} · {k.provider} · ••••{k.preview}
+          {k.lastUsedAt ? ` · used ${new Date(k.lastUsedAt).toLocaleDateString()}` : " · unused"}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/apps/web/src/lib/sse.ts
+++ b/apps/web/src/lib/sse.ts
@@ -1,0 +1,79 @@
+/**
+ * Minimal POST-capable SSE client. EventSource can't POST, so we do it
+ * manually: fetch with a ReadableStream body, parse the text stream
+ * into SSE events (`event:` + `data:` blank-line-separated).
+ */
+
+export interface SSEEvent {
+  event: string;
+  data: string;
+}
+
+export interface OpenSSEOptions {
+  url: string;
+  body: unknown;
+  signal?: AbortSignal;
+  onEvent: (event: SSEEvent) => void;
+  onError?: (err: unknown) => void;
+  onClose?: () => void;
+}
+
+export async function openSSE(options: OpenSSEOptions): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch(options.url, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "text/event-stream" },
+      body: JSON.stringify(options.body),
+      signal: options.signal,
+    });
+  } catch (err) {
+    options.onError?.(err);
+    options.onClose?.();
+    return;
+  }
+
+  if (!response.ok || !response.body) {
+    options.onError?.(new Error(`SSE open failed: ${response.status}`));
+    options.onClose?.();
+    return;
+  }
+
+  const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+  let buffer = "";
+
+  try {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += value;
+
+      let boundary = buffer.indexOf("\n\n");
+      while (boundary !== -1) {
+        const raw = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+        const parsed = parseEvent(raw);
+        if (parsed) options.onEvent(parsed);
+        boundary = buffer.indexOf("\n\n");
+      }
+    }
+  } catch (err) {
+    if (!(err instanceof DOMException && err.name === "AbortError")) {
+      options.onError?.(err);
+    }
+  } finally {
+    options.onClose?.();
+  }
+}
+
+function parseEvent(raw: string): SSEEvent | null {
+  let event = "message";
+  let data = "";
+  for (const line of raw.split("\n")) {
+    if (line.startsWith("event:")) event = line.slice(6).trim();
+    else if (line.startsWith("data:")) data += (data ? "\n" : "") + line.slice(5).trim();
+  }
+  if (!data) return null;
+  return { event, data };
+}

--- a/packages/collector/src/router.ts
+++ b/packages/collector/src/router.ts
@@ -9,6 +9,7 @@ import { createBreakpointRoutes } from "./routes/breakpoints.js";
 import { createReplayRoutes } from "./routes/replay.js";
 import { createOtlpRoutes } from "./routes/otlp.js";
 import { createFixRoutes } from "./routes/fix.js";
+import { createFixApplyRoutes } from "./routes/fix-apply.js";
 import { createKeyRoutes } from "./routes/keys.js";
 
 interface RouterContext {
@@ -33,6 +34,7 @@ export async function createRouter(ctx: RouterContext) {
   app.route("/v1/replay", createReplayRoutes());
   app.route("/v1/otlp", createOtlpRoutes(ctx.db));
   app.route("/v1/fix", createFixRoutes());
+  app.route("/v1/fix-apply", createFixApplyRoutes());
 
   // BYOK key management — nested under /v1/projects/:id/keys. Only
   // mounted when a KeyStore is provided (requires PATHLIGHT_SEAL_KEY).

--- a/packages/collector/src/routes/fix-apply.ts
+++ b/packages/collector/src/routes/fix-apply.ts
@@ -1,0 +1,101 @@
+/**
+ * `POST /v1/fix-apply` — writes a diff to the caller's local working tree
+ * via `git apply`. Self-hosted trust model applies (parent invariant #4:
+ * auth is deferred). The route runs `git apply --check` first and only
+ * writes if the dry run succeeds.
+ *
+ * IMPORTANT: this route executes a single hard-coded command (`git apply`)
+ * with a user-supplied `sourceDir` as cwd and a user-supplied diff on stdin.
+ * It does NOT evaluate any other command. Trust boundary is the self-hosted
+ * collector == the dev tree; in a hosted deployment this route should be
+ * disabled via an operator flag.
+ */
+
+import { Hono } from "hono";
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+
+interface ApplyBody {
+  sourceDir?: unknown;
+  diff?: unknown;
+}
+
+export function createFixApplyRoutes() {
+  const app = new Hono();
+
+  app.post("/", async (c) => {
+    let body: ApplyBody;
+    try {
+      body = await c.req.json<ApplyBody>();
+    } catch {
+      return c.json({ error: { message: "invalid json body", type: "validation_error" } }, 400);
+    }
+
+    if (typeof body.sourceDir !== "string" || body.sourceDir.length === 0) {
+      return c.json({ error: { message: "sourceDir required", type: "validation_error" } }, 400);
+    }
+    if (typeof body.diff !== "string" || body.diff.length === 0) {
+      return c.json({ error: { message: "diff required", type: "validation_error" } }, 400);
+    }
+
+    const cwd = resolve(body.sourceDir);
+    const diff = body.diff;
+
+    try {
+      await runGitApply(["apply", "--check", "--whitespace=nowarn", "-"], cwd, diff);
+    } catch (err) {
+      return c.json(
+        {
+          error: {
+            message: "diff failed git apply --check",
+            type: "apply_precheck_failed",
+            detail: err instanceof Error ? err.message : String(err),
+          },
+        },
+        409,
+      );
+    }
+
+    try {
+      await runGitApply(["apply", "--whitespace=nowarn", "-"], cwd, diff);
+    } catch (err) {
+      return c.json(
+        {
+          error: {
+            message: "git apply failed after passing --check",
+            type: "apply_failed",
+            detail: err instanceof Error ? err.message : String(err),
+          },
+        },
+        500,
+      );
+    }
+
+    return c.json({ applied: true });
+  });
+
+  return app;
+}
+
+function runGitApply(args: string[], cwd: string, stdin: string): Promise<void> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn("git", args, {
+      cwd,
+      stdio: ["pipe", "ignore", "pipe"],
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+
+    let stderr = "";
+    child.stderr.on("data", (d: Buffer) => {
+      stderr += d.toString("utf-8");
+    });
+    child.on("error", (err) => rejectPromise(err));
+    child.on("exit", (code) => {
+      if (code === 0) resolvePromise();
+      else rejectPromise(new Error(stderr.trim() || `git apply exited with code ${code ?? "unknown"}`));
+    });
+
+    child.stdin.write(stdin);
+    child.stdin.end();
+  });
+}


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 49
branch: issue/49-dashboard-fix
status: resolved
updated_at: 2026-04-24T19:30:00Z
review_status: awaiting-review
-->

## Summary

Flagship UX surface for the code-fixing agent. Failed spans in the trace inspector get a "Fix this" button that opens a dialog with source/provider/mode/key picker, streams the engine's SSE progress in real time, renders the unified diff with per-file expand/collapse + add/remove colorization, and offers three end-actions: apply to the working tree (via a new \`POST /v1/fix-apply\` collector route), download .patch, copy to clipboard. Bisect runs surface a banner with the identified regression SHA linking back to the /commits view.

Closes #49
Parent: #44

## Review Status

- **Current state:** awaiting review
- **Last reviewed by:** none yet
- **Last reviewed at:** n/a
- **Reviewed commit:** n/a
- **Source artifact:** none yet
- **Needs re-review since:** no

## Journey Timeline

### Initial Plan

Eight tasks from #49: button, dialog/form, key picker, SSE stream, diff preview (tier-1), apply-to-tree + new route, download/copy, bisect banner.

### What We Discovered

- **EventSource can't POST.** The /v1/fix route consumes a JSON body, so the dashboard needed a fetch-based SSE client. Built a small \`lib/sse.ts\` (fetch + ReadableStream + TextDecoder + blank-line-split parser, ~60 lines) rather than adding a library.
- **Diff viewer dep was unnecessary.** Considered \`react-diff-viewer-continued\` (~50KB gz). Rolled our own unified-diff parser + renderer at ~5KB. Side-by-side layout wasn't needed for v1.
- **Dialog needed a phase state machine.** Going from \`idle → streaming → done | error\` rather than independent booleans kept the post-result UI composable (banner + explanation + diff + actions all driven from the same discriminated union).

### Implementation Issues

- None material during implementation. One setup-time item: the #49 base required integrating both #47 and #48. Handled by branching off \`issue/48-byok-storage\` and merging \`issue/47-fix-web-api\` (conflicts in \`packages/collector/{package.json,src/router.ts}\`) as a dedicated integration commit so the UI build could see both backends.

### Key Decisions Made

| Decision | Choice | Why |
|---|---|---|
| Base composition | #48 branch + merged #47 | Collector must have both /v1/fix (SSE) and /v1/projects/:id/keys (keys) available so the UI can build against real routes |
| SSE client | Handwritten POST-capable, no dep | EventSource can't POST; the parser is ~60 lines |
| Diff viewer | Roll our own unified viewer | ~5KB vs ~50KB; no a11y/palette coupling to a 3rd-party lib |
| Dialog state | Discriminated union (idle/streaming/done/error) | Each UI branch explicit; no booleans-that-disagree class of bugs |
| Apply route | Hardcoded \`git apply\` with \`--check\` precheck | No shell interpolation, no other commands. Self-hosted trust model per parent invariant #4 |
| Bisect banner | Short SHAs only, link to /commits | Collector has no git-metadata-by-sha API; keep the banner lean rather than adding one just for this |

### Changes Made

**Commits:**

\`\`\`
06a65a4 feat(#49/T8): bisect result banner above the fix preview
b6b96b2 feat(#49/T7): download .patch + copy-to-clipboard actions
94fe922 feat(#49/T6): apply-to-working-tree route + UI button
375bb1d feat(#49/T5): unified diff preview viewer
ae2ea44 feat(#49/T4): SSE stream + progress UI
5bf24cb feat(#49/T3): Key picker sourced from /v1/projects/:id/keys
5a6528d feat(#49/T2): Fix dialog form with validation
ff65a56 feat(#49/T1): Fix-this button + dialog shell on span inspector
514a899 merge(integration): bring #47 web-API route into #49 base for UI build
\`\`\`

**New components:** \`apps/web/src/components/Fix/\` — FixButton, FixDialog, FixForm, KeyPicker, FixStream, DiffPreview, DiffActions, BisectBanner
**New lib:** \`apps/web/src/lib/sse.ts\` — POST-capable SSE client
**New collector route:** \`packages/collector/src/routes/fix-apply.ts\` — POST /v1/fix-apply

## Testing

- [x] \`npx turbo build\` — all 8 packages build clean
- [x] Self-audit — each component is single-purpose; dialog owns the phase state; secrets never flow through the UI (keyId only, never the plaintext value)

**Not yet smoke-tested against a live engine.** Running the stack with real keys + a failing trace produces the full flow; that's the acceptance event. UI Storybook / visual regression testing deferred.

## Stacked PRs / Related

- Parent: #44
- Stacked on: #45 (engine), #47 (SSE route), #48 (key store)
- The merge commit \`514a899\` pulls #47 into the #48-based branch. When the three dependencies land, GitHub resolves the transitive base; merge order among #51/#52/#53 does not affect this PR.

## Knowledge for Future Reference

- \`lib/sse.ts\` is the general-purpose POST-SSE client; any future routes that want to stream to the dashboard can reuse it.
- \`DiffPreview\` parses unified-diff text — not generic diff. If the engine emits a different format in the future, this is the integration point.
- The apply route \`POST /v1/fix-apply\` is the only route in the collector that mutates the host filesystem. If hosted Pathlight ever exists, gate it behind an operator flag (or just don't mount it) before exposing publicly.
- The \`FixDialog\` phase state is the canonical model. If a new lifecycle step needs to land (e.g. an explicit "resolving secrets" phase from the server), extend the union rather than sprinkling booleans.

---
Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*