### PR TITLE
docs: P5 post-ship sync — fix-engine, BYOK storage, OpenClaw plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,83 @@ All notable changes to Pathlight. Dates are release days, not merge days.
 
 ## Unreleased
 
+### Added — Code-fixing agent ([#44](https://github.com/syndicalt/pathlight/issues/44))
+- New `@pathlight/fix` library. Pure `fix({ traceId, collectorUrl, source, llm, mode })`
+  function reads a failing trace, pulls the source files the spans referenced
+  (via `_source.file` metadata), and returns a unified diff + explanation.
+- **BYOK** — user brings their own Anthropic or OpenAI key. Pathlight never
+  acts as an inference proxy. Keys are never logged, never emitted in traces,
+  never echoed in errors. `FixError.cause` is non-enumerable so default
+  stringification paths can't walk into SDK error payloads that echo headers.
+- **Three source modes**: `{ kind: "path", dir }` reads a local tree;
+  `{ kind: "git", repoUrl, token, ref? }` shallow-clones into a tempdir with
+  read-only tokens only; bisect deepens the clone automatically as needed.
+- **Three fix modes**: `span` (fix the failing span[s]), `trace` (whole
+  trace), `bisect` (binary-search a commit range for the regression commit
+  in O(log₂ N) probes, propose a fix against that SHA).
+- **Structured tool-use output.** Both Anthropic and OpenAI adapters expose
+  the same `complete({ messages, tools })` interface and return the model's
+  diff via a `propose_fix` tool call — no prose parsing.
+- **Meta-trace emission** on every invocation. Carries mode, source kind,
+  provider, model, token counts, files-changed — never the diff body,
+  never keys/tokens.
+- New CLI subcommand `pathlight fix <trace-id>` with `--source-dir` /
+  `--git-url` / `--provider` / `--model` / `--apply` / `--bisect` /
+  `--from` / `--to` flags. Key from `PATHLIGHT_LLM_API_KEY` env,
+  token from `PATHLIGHT_GIT_TOKEN`. Progress prints to stderr so stdout
+  stays pipeable.
+- New collector route `POST /v1/fix` streams the engine over SSE
+  (`progress` / `chunk` / `result` / `error` / `done`).
+- New collector route `POST /v1/fix-apply` writes a diff to a local
+  working tree via `git apply` with an explicit `--check` precheck.
+- Dashboard adds **"Fix this"** button on every failed span's inspector.
+  Dialog includes source picker, provider + BYOK key picker, mode selector,
+  live SSE progress stream, unified diff viewer with per-file expand /
+  collapse + add/remove colorization, **Apply to working tree** / **Download
+  .patch** / **Copy** actions, and a **Bisect result** banner when the run
+  identifies a regression commit.
+- New example apps: `examples/fix-hello-world/` (path-mode loop against a
+  deliberately-buggy agent), `examples/fix-bisect-regression/` (git + bisect
+  walkthrough with a known regression).
+- Docs: [docs/fix.md](docs/fix.md).
+
+### Added — BYOK encrypted key storage ([#48](https://github.com/syndicalt/pathlight/issues/48))
+- New `@pathlight/keys` internal package backed by libsodium
+  `crypto_secretbox_easy` (authenticated encryption, fresh nonce per value).
+- New `api_keys` table in `@pathlight/db` with `kind` (`llm` | `git`),
+  `provider`, `label`, `sealed_value`, `preview` (last 4 chars for UI mask).
+- Collector routes `POST/GET/PUT/DELETE /v1/projects/:id/keys` — mounted
+  only when `PATHLIGHT_SEAL_KEY` (32-byte base64) is set. Fail-stop on
+  missing/malformed. All responses are masked metadata; plaintext never
+  leaves the server.
+- Cross-project access returns `null` (same shape as not-found). Cross-kind
+  access on the `SecretResolver` returns `null` to prevent mis-typed secrets
+  flowing into the wrong API.
+- `SecretResolver` adapter plugs into `POST /v1/fix` so the dashboard
+  drives fix runs with stored key IDs — plaintext never touches the browser.
+- New dashboard page `/settings/keys` — per-project list with add / rotate
+  (atomic) / revoke flows; values masked as `••••••••<last-4>`.
+- `packages/keys/LEAK-AUDIT.md` documents six grep-based audit probes + four
+  runtime probes that every release must pass.
+- Docs: [docs/byok-keys.md](docs/byok-keys.md).
+
+### Added — OpenClaw plugin ([#42](https://github.com/syndicalt/pathlight/issues/42))
+- New `@pathlight/openclaw` npm package — a native OpenClaw plugin that
+  captures agent runs, LLM calls, tool execution, and sub-agent delegation
+  as Pathlight traces, with `git_commit` / `git_branch` / `git_dirty`
+  automatically attached to every trace.
+- Install: `openclaw plugins install @pathlight/openclaw`. Configure via
+  `PATHLIGHT_BASE_URL` / `PATHLIGHT_API_KEY` / `PATHLIGHT_PROJECT_ID` env
+  (or OpenClaw plugin-config file; precedence: config > env > defaults).
+- Hooks wired: `before_agent_start` / `agent_end`, `llm_input` / `llm_output`,
+  `before_tool_call` / `after_tool_call`, `subagent_spawning` / `subagent_ended`.
+  Memory hooks deferred until the upstream surface stabilizes.
+- Graceful degradation: unreachable collector logs one warning and
+  continues best-effort; hook throws are caught in a shared `safeOn` wrapper
+  so a single bad hook can't take down the plugin.
+- Shipped with an `examples/openclaw-hello-world/` starter.
+- Docs: [docs/openclaw-plugin.md](docs/openclaw-plugin.md).
+
 ### Added — Docker Compose + prebuilt GHCR images
 - `docker compose up -d` starts collector + dashboard with a named SQLite
   volume; migrations run automatically on first boot.
@@ -11,6 +88,13 @@ All notable changes to Pathlight. Dates are release days, not merge days.
   at the repo root. Web image uses Next.js 15 standalone output.
 - GitHub Actions workflow publishes tagged + `:latest` images to
   `ghcr.io/syndicalt/pathlight-{collector,web}` on every push to master.
+
+### Changed
+- TopNav gains a **Settings** link (`/settings/keys`) and bumps the version
+  badge to v0.3.0.
+- Collector router mounts `/v1/fix` unconditionally and
+  `/v1/projects/:id/keys` only when `PATHLIGHT_SEAL_KEY` is set — BYOK is
+  opt-in per deployment.
 
 ### Fixed
 - `@pathlight/db` now ships a proper compiled build (`main` was pointing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,22 +11,38 @@ Turborepo monorepo with npm workspaces:
 
 - `packages/collector` — Hono-based trace collector API on port 4100.
   Receives traces/spans/events, serves SSE streams, proxies LLM replays,
-  hosts the in-memory breakpoint registry.
+  hosts the in-memory breakpoint registry, runs the `POST /v1/fix` SSE
+  wrapper, and mounts BYOK `/v1/projects/:id/keys` (only when
+  `PATHLIGHT_SEAL_KEY` is set).
 - `packages/db` — Drizzle ORM + SQLite. Schema: traces, spans, events,
-  projects, scores. Traces carry `git_commit`/`git_branch`/`git_dirty` and
-  `reviewed_at`.
+  projects, scores, api_keys. Traces carry `git_commit`/`git_branch`/`git_dirty`
+  and `reviewed_at`. `api_keys` holds libsodium-sealed BYOK secrets.
 - `packages/sdk` — TypeScript SDK for instrumenting agents. Auto-captures
   source locations + git context. Exposes `tl.breakpoint()` for live
   debugging.
 - `packages/eval` — `@pathlight/eval` assertion DSL and `pathlight-eval`
   CI runner.
-- `packages/cli` — `@pathlight/cli` with `pathlight share` subcommand for
-  exporting single-file HTML trace snapshots.
+- `packages/cli` — `@pathlight/cli` with two subcommands: `pathlight share`
+  (single-file HTML trace snapshot) and `pathlight fix` (BYOK code-fixing
+  agent with path/git/bisect modes).
 - `packages/sdk-python` — `pathlight` on PyPI. Sync + async clients,
   context managers, full feature parity with the TS SDK.
+- `packages/fix` — `@pathlight/fix` code-fixing agent core. `fix()` reads
+  a failing trace, pulls source files via `_source.file` metadata, runs
+  a BYOK LLM (Anthropic or OpenAI), returns a unified diff. Supports
+  path / git / bisect source modes. See [docs/fix.md](docs/fix.md).
+- `packages/keys` — `@pathlight/keys` encrypted key storage (internal).
+  libsodium `crypto_secretbox_easy`; plaintext never stored. Security
+  invariants tracked in `packages/keys/LEAK-AUDIT.md`. See
+  [docs/byok-keys.md](docs/byok-keys.md).
+- `packages/openclaw-plugin` — `@pathlight/openclaw` OpenClaw plugin.
+  Hooks `before_agent_start`/`agent_end`, LLM I/O, tool calls, and
+  sub-agent delegation into Pathlight traces. See
+  [docs/openclaw-plugin.md](docs/openclaw-plugin.md).
 - `apps/web` — Next.js + Tailwind dashboard (port 3100). Routes: `/`
-  (list), `/traces/[id]` (detail + side-by-side inspector), `/traces/compare`
-  (diff), `/commits` (regression view).
+  (list), `/traces/[id]` (detail + side-by-side inspector + **Fix this**
+  dialog), `/traces/compare` (diff), `/commits` (regression view),
+  `/settings/keys` (BYOK key management).
 - Root-level `Dockerfile.collector` + `Dockerfile.web` + `docker-compose.yml`
   ship the stack. GHCR publishes `ghcr.io/syndicalt/pathlight-{collector,web}`
   on every push to master.
@@ -58,6 +74,12 @@ npm run db:retire -w packages/db -- --delete              # Delete instead
 # CLIs
 pathlight share <trace-id> --out ./snapshot.html
 pathlight-eval specs/estimate.mjs --base-url http://localhost:4100
+
+# Code-fixing agent (BYOK)
+export PATHLIGHT_LLM_API_KEY=sk-ant-...
+pathlight fix <trace-id> --source-dir . --apply
+pathlight fix <trace-id> --git-url <url> --provider openai
+pathlight fix <trace-id> --bisect --from <good> --to <bad> --git-url <url>
 ```
 
 ## Key data model
@@ -65,11 +87,14 @@ pathlight-eval specs/estimate.mjs --base-url http://localhost:4100
 - **Trace** — A complete agent execution. Status, input/output, duration,
   tokens, cost, git provenance, `reviewedAt`.
 - **Span** — A single step. Types: llm, tool, retrieval, agent, chain,
-  custom. Nests via `parentSpanId`.
+  custom. Nests via `parentSpanId`. Auto-captured `metadata._source =
+  { file, line, column, func }` powers fix-engine file inference.
 - **Event** — Point-in-time annotation within a span (logs, decisions,
   errors).
 - **Score** — Quality annotation on a trace or span.
 - **Project** — Groups traces; has an API key for SDK auth.
+- **ApiKey** — BYOK LLM/git secret, per project. Ciphertext + masked
+  preview only; plaintext never stored or returned.
 
 ## SDK usage
 
@@ -88,16 +113,56 @@ trace.end({ output: finalResult });
 const state = await tl.breakpoint({ label: "checkpoint", state: { foo } });
 ```
 
+## Fix-engine usage
+
+```typescript
+import { fix } from "@pathlight/fix";
+
+const result = await fix({
+  traceId: "trc_xxx",
+  collectorUrl: "http://localhost:4100",
+  source: { kind: "path", dir: "/abs/path" },        // or { kind: "git", ... }
+  llm: { provider: "anthropic", apiKey: process.env.ANTHROPIC_API_KEY! },
+  mode: { kind: "span" },                            // "span" | "trace" | "bisect"
+});
+// result.diff, result.explanation, result.filesChanged
+// result.regressionSha (bisect only)
+```
+
 ## Notable UI conventions
 
 - **Top nav** (`apps/web/src/components/TopNav.tsx`) — sticky horizontal
-  header with logo, version, right-aligned page links. Replaces the old
-  fixed left sidebar.
+  header with logo, version, right-aligned page links (Traces, Commits,
+  Settings). Replaces the old fixed left sidebar.
 - **Span inspector** — side-by-side with the timeline when a span is
   selected. Timeline narrows to `0.8fr`; inspector takes `1.2fr` and is
-  sticky.
+  sticky. **"Fix this" button** appears on failed spans (driven by the
+  `spanHasIssues` heuristic).
+- **Fix dialog** (`apps/web/src/components/Fix/`) — modal with phase state
+  machine (`idle → streaming → done | error`). Streams `/v1/fix` SSE via
+  the POST-capable client at `apps/web/src/lib/sse.ts`. Renders unified
+  diff in a roll-our-own viewer (no react-diff-viewer dep).
 - **Breakpoints panel** (`BreakpointsPanel.tsx`) — globally mounted in
   `layout.tsx`. Auto-opens on new breakpoint arrival.
+- **Settings pages** (`/settings/*`) — add/manage BYOK keys; masked
+  display only, plaintext inaccessible after creation.
+
+## BYOK security invariants
+
+See `packages/keys/LEAK-AUDIT.md` for the per-release checklist. Short version:
+
+1. Plaintext is NEVER stored — every write goes through `seal()`.
+2. Plaintext is NEVER logged — `console.*`, errors, traces, responses.
+3. Endpoints NEVER return plaintext — `POST` returns masked metadata;
+   the only plaintext-return path is internal `resolveSecret` for
+   outbound LLM calls.
+4. `PATHLIGHT_SEAL_KEY` is required — fail-stop on missing/malformed.
+5. Cross-project access returns `null` (same shape as not-found).
+
+The fix-engine follows the same rules: `FixError.cause` is non-enumerable,
+error messages are scrubbed via `makeRedactor()` before any write, and the
+`fix.engine` meta-trace carries only metadata (lengths, token counts) —
+never the diff body, explanation text, API key, or git token.
 
 ## Conventions
 
@@ -107,8 +172,12 @@ const state = await tl.breakpoint({ label: "checkpoint", state: { foo } });
   `packages/collector/pathlight.db` for CLI migrations). Docker handles
   this automatically on container boot.
 - Workspace packages `@pathlight/db`, `@pathlight/sdk`, `@pathlight/eval`,
-  `@pathlight/cli` all compile to `dist/` via `tsc`. **Don't** switch any
-  of them back to `main: ./src/*.ts` — it breaks production `node`
-  execution (only works under `tsx`).
+  `@pathlight/cli`, `@pathlight/fix`, `@pathlight/keys`,
+  `@pathlight/openclaw` all compile to `dist/` via `tsc`. **Don't**
+  switch any of them back to `main: ./src/*.ts` — it breaks production
+  `node` execution (only works under `tsx`).
 - Empty directories aren't tracked by git. If a new empty dir needs to
   exist for Docker COPY to work, add a `.gitkeep` (see `apps/web/public/`).
+- BYOK is a hard line. The code-fixing agent, LLM replay, and OpenClaw
+  plugin all use the user's own keys; Pathlight never acts as an
+  inference proxy.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ No more debugging agents with `console.log`.
 | **Live breakpoints** | `await tl.breakpoint(...)` pauses your agent; edit state on the dashboard and resume | [docs/breakpoints.md](docs/breakpoints.md) |
 | **LLM replay** | Edit messages on any LLM span and re-run against the real provider | [docs/replay.md](docs/replay.md) |
 | **Eval-as-code + CI** | `expect(trace).toCostLessThan(0.10)` — assert over recent traces, exit nonzero in CI | [packages/eval/README.md](packages/eval/README.md) |
+| **Code-fixing agent** | BYOK LLM reads your failing trace + source and proposes a unified diff. CLI, dashboard button, `bisect` across commits. | [docs/fix.md](docs/fix.md) |
+| **BYOK key storage** | Encrypted-at-rest LLM keys + git tokens per project. Dashboard picker uses stored IDs; plaintext never touches the browser. | [docs/byok-keys.md](docs/byok-keys.md) |
+| **OpenClaw plugin** | `@pathlight/openclaw` captures OpenClaw agent runs, LLM calls, tool execution, and sub-agent delegation with git provenance. | [docs/openclaw-plugin.md](docs/openclaw-plugin.md) |
 | **`pathlight share`** | Single-file HTML snapshot of a trace, zero deps to open | [packages/cli/README.md](packages/cli/README.md) |
 | **OpenTelemetry interop** | Collector accepts OTLP/HTTP; any OTel-instrumented app can ship to Pathlight | [docs/opentelemetry.md](docs/opentelemetry.md) |
 | **Python SDK** | `pip install pathlight` — same dashboard features, Pythonic API, sync + async | [docs/python.md](docs/python.md) |
@@ -132,6 +135,22 @@ waterfall, source locations, token counts, and git provenance.
 2. Attach the HTML to your GitHub issue / Slack thread. They open it in any
    browser — no dashboard, no server, no dependencies.
 
+### "Fix this failing trace without leaving the dashboard."
+1. Open the failing trace, click the broken span.
+2. Click **Fix this** in the inspector header. Pick a source (local path or
+   remote git URL), a provider key from your BYOK store, and a mode
+   (span / trace / bisect).
+3. SSE streams progress. Diff preview renders per-file with add/remove
+   colorization. Click **Apply to working tree** (path mode) or
+   **Download .patch**. See [docs/fix.md](docs/fix.md).
+
+### "Which commit broke this agent?"
+1. From the CLI: `pathlight fix <trace-id> --bisect --from <good-sha> --to <bad-sha> --git-url <url>`
+2. Binary-search walks the commit range in O(log N) probes and returns the
+   regression SHA plus a proposed fix against that commit.
+3. In the dashboard: pick mode **Bisect** in the fix dialog — the result
+   screen shows a banner with the regression SHA linking to `/commits`.
+
 ---
 
 ## What you see
@@ -199,7 +218,10 @@ pathlight/
 │           │   └── commits/page.tsx        # Per-commit regression view
 │           ├── components/
 │           │   ├── TopNav.tsx              # Sticky horizontal nav
-│           │   └── BreakpointsPanel.tsx    # Floating badge + slide-out editor
+│           │   ├── BreakpointsPanel.tsx    # Floating badge + slide-out editor
+│           │   └── Fix/                    # "Fix this" dialog — button, form, key picker,
+│           │                               # SSE stream, diff preview, apply/download/copy,
+│           │                               # bisect banner
 │           └── lib/
 │               ├── api.ts                  # Collector fetch helpers
 │               ├── diff.ts                 # LCS line-diff utility
@@ -213,7 +235,10 @@ pathlight/
 │   │       │   ├── projects.ts      # Project CRUD
 │   │       │   ├── breakpoints.ts   # Live breakpoint register/wait/resume/SSE
 │   │       │   ├── replay.ts        # LLM replay proxy (OpenAI + Anthropic)
-│   │       │   └── otlp.ts          # OTLP/HTTP ingest (gen_ai.* mapping)
+│   │       │   ├── otlp.ts          # OTLP/HTTP ingest (gen_ai.* mapping)
+│   │       │   ├── fix.ts           # POST /v1/fix — SSE wrapper around @pathlight/fix
+│   │       │   ├── fix-apply.ts     # POST /v1/fix-apply — git apply a diff locally
+│   │       │   └── keys.ts          # BYOK key CRUD (mounted only when PATHLIGHT_SEAL_KEY is set)
 │   │       ├── events.ts            # Trace EventEmitter for SSE fan-out
 │   │       ├── breakpoints.ts       # In-memory breakpoint registry
 │   │       └── router.ts            # CORS + route mounting
@@ -235,11 +260,34 @@ pathlight/
 │   │   ├── bin/pathlight-eval.js
 │   │   ├── examples/
 │   │   └── src/index.ts             # expect() matchers, evaluate()
-│   └── cli/              # pathlight CLI (subcommand router)
-│       ├── bin/pathlight.js
+│   ├── cli/              # pathlight CLI (subcommand router)
+│   │   ├── bin/pathlight.js
+│   │   └── src/
+│   │       ├── commands/share.ts    # pathlight share <trace-id>
+│   │       ├── commands/fix.ts      # pathlight fix <trace-id> — path/git/bisect modes
+│   │       └── viewer-template.ts   # Self-contained HTML viewer
+│   ├── fix/              # Code-fixing agent core — @pathlight/fix
+│   │   └── src/
+│   │       ├── index.ts             # fix() entry + composition
+│   │       ├── types.ts             # FixOptions / FixResult / FixMode / FixProgress
+│   │       ├── source/{path,git}.ts # SourceReader implementations
+│   │       ├── llm/{anthropic,openai}.ts  # BYOK adapters behind a shared interface
+│   │       ├── bisect.ts            # O(log N) regression search
+│   │       ├── prompt.ts            # Trace + source → LLM messages; PROPOSE_FIX_TOOL schema
+│   │       ├── diff-parser.ts       # Tool-call → parsed unified diff
+│   │       └── secrets.ts           # Token/key redaction for error paths
+│   ├── keys/             # BYOK encrypted key storage — @pathlight/keys (internal)
+│   │   ├── LEAK-AUDIT.md            # Per-release security checklist
+│   │   └── src/
+│   │       ├── seal.ts              # libsodium crypto_secretbox primitives
+│   │       ├── seal-key.ts          # PATHLIGHT_SEAL_KEY loader (fail-stop on missing)
+│   │       ├── store.ts             # KeyStore: create/list/rotate/revoke/resolveSecret
+│   │       └── resolver.ts          # SecretResolver adapter for /v1/fix
+│   └── openclaw-plugin/  # OpenClaw tracing plugin — @pathlight/openclaw
 │       └── src/
-│           ├── commands/share.ts    # pathlight share <trace-id>
-│           └── viewer-template.ts   # Self-contained HTML viewer
+│           ├── index.ts             # definePluginEntry wiring
+│           ├── hooks/               # trace-envelope, llm, tool, delegation
+│           └── state.ts             # Per-run state (trace + in-flight spans)
 ├── Dockerfile.collector  # Multi-stage build; migrations run on boot
 ├── Dockerfile.web        # Next.js 15 standalone runtime
 ├── docker-compose.yml    # Collector + dashboard + SQLite volume
@@ -308,6 +356,24 @@ pathlight/
 | Endpoint | Method | Description |
 | --- | --- | --- |
 | `/v1/otlp/traces` | POST | OTLP/HTTP JSON ingest. Accepts `resourceSpans[...]`. Maps `gen_ai.*` attributes to Pathlight fields. See [OTel docs](docs/opentelemetry.md). |
+
+### Fix engine
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/v1/fix` | POST | Run `@pathlight/fix` against a failing trace. Response is `text/event-stream` with `progress` / `chunk` / `result` / `error` / `done` events. Resolves `keyId`/`tokenId` via the BYOK key store. See [docs/fix.md](docs/fix.md). |
+| `/v1/fix-apply` | POST | Write a unified diff to a local working tree via `git apply`. Body: `{ sourceDir, diff }`. Runs `git apply --check` first. |
+
+### BYOK key storage
+
+Only mounted when `PATHLIGHT_SEAL_KEY` is set. See [docs/byok-keys.md](docs/byok-keys.md).
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/v1/projects/:id/keys` | GET | List keys — masked metadata only |
+| `/v1/projects/:id/keys` | POST | Create a key: `{ kind, provider, label, value }` |
+| `/v1/projects/:id/keys/:keyId` | PUT | Atomically rotate |
+| `/v1/projects/:id/keys/:keyId` | DELETE | Revoke immediately |
 
 ### Projects
 
@@ -429,6 +495,9 @@ individual amber-highlighted rows in the waterfall.
 | `REPLAY_BASE_URL` | — | Base URL for OpenAI-compatible replay (e.g. `https://gateway.provara.xyz`). Accepts with or without trailing `/v1` |
 | `OPENAI_API_KEY` | — | Fallback key when `REPLAY_API_KEY` isn't set and provider is OpenAI-compatible |
 | `ANTHROPIC_API_KEY` | — | Fallback key when `REPLAY_API_KEY` isn't set and provider is Anthropic |
+| `PATHLIGHT_SEAL_KEY` | — | 32-byte base64 master key for the BYOK encrypted key store. When set, the collector mounts `/v1/projects/:id/keys`. Fail-stops on malformed input. |
+| `PATHLIGHT_LLM_API_KEY` | — | BYOK LLM key consumed by `pathlight fix`. Required for the CLI. |
+| `PATHLIGHT_GIT_TOKEN` | — | Read-only git token consumed by `pathlight fix --git-url`. Never logged. |
 
 ---
 
@@ -459,6 +528,12 @@ npm run db:retire -w packages/db -- --delete ../collector/pathlight.db  # Delete
 # CLIs (after install)
 pathlight share <trace-id> --out report.html
 pathlight-eval specs/my-checks.mjs --base-url http://localhost:4100
+
+# Code-fixing agent (BYOK)
+export PATHLIGHT_LLM_API_KEY=sk-ant-...
+pathlight fix <trace-id> --source-dir . --apply
+pathlight fix <trace-id> --git-url https://github.com/acme/repo.git --provider openai
+pathlight fix <trace-id> --bisect --from <good> --to <bad> --git-url <url>
 ```
 
 ---
@@ -476,9 +551,14 @@ pathlight-eval specs/my-checks.mjs --base-url http://localhost:4100
 ## Self-hosted philosophy
 
 Everything runs locally by default. SQLite file, single collector process,
-no external services required. API keys (for replay) read from env vars or
-stay in the browser's `localStorage` — never sent to any third-party beyond
-the LLM provider itself.
+no external services required. API keys (for replay and BYOK fix) read from
+env vars, from the browser's `localStorage`, or from the encrypted
+libsodium-backed key store — never sent to any third-party beyond the LLM
+provider itself.
+
+**BYOK is a hard line.** The code-fixing agent, LLM replay, and OpenClaw
+plugin all use the user's own keys. Pathlight never acts as an inference
+proxy and never stores plaintext keys at rest.
 
 ## License
 

--- a/apps/web/src/components/TopNav.tsx
+++ b/apps/web/src/components/TopNav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 const LINKS = [
   { href: "/", label: "Traces", match: (p: string) => p === "/" || p.startsWith("/traces") },
   { href: "/commits", label: "Commits", match: (p: string) => p.startsWith("/commits") },
+  { href: "/settings/keys", label: "Settings", match: (p: string) => p.startsWith("/settings") },
 ];
 
 export function TopNav() {
@@ -17,7 +18,7 @@ export function TopNav() {
         <Link href="/" className="text-base font-bold tracking-tight shrink-0">
           <span className="text-blue-400">Path</span>light
         </Link>
-        <span className="text-[10px] text-zinc-600 shrink-0">v0.1.0</span>
+        <span className="text-[10px] text-zinc-600 shrink-0">v0.3.0</span>
         <nav className="ml-auto flex items-center gap-1">
           {LINKS.map((l) => {
             const active = l.match(pathname);

--- a/docs/byok-keys.md
+++ b/docs/byok-keys.md
@@ -1,0 +1,78 @@
+# BYOK key storage
+
+Encrypted-at-rest storage for the LLM API keys and git read-only tokens the code-fixing agent uses from the dashboard. Library and CLI callers still pass keys directly (via env vars or function arguments); the key store exists so the dashboard can drive fix runs without ever holding plaintext in the browser.
+
+## Enable
+
+Set a 32-byte base64 master key before starting the collector:
+
+```bash
+# Generate once, store somewhere safe (password manager, secrets manager)
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+
+# Set on the collector process
+export PATHLIGHT_SEAL_KEY=<the-base64-value>
+docker compose up -d   # or `npx turbo dev`
+```
+
+When `PATHLIGHT_SEAL_KEY` is set the collector loads [`@pathlight/keys`](../packages/keys) and mounts `/v1/projects/:id/keys`. When it's absent the endpoints simply aren't mounted — existing deployments without BYOK keep working.
+
+The collector **fail-stops** (`process.exit(1)`) if `PATHLIGHT_SEAL_KEY` is present but malformed. No default fallback, no insecure generation.
+
+## Manage keys
+
+Open `http://localhost:3100/settings/keys`:
+
+1. Enter a project ID (free-text for now; will come from session auth once auth lands).
+2. Click **Add a key** — pick kind (LLM key or git token), provider (anthropic / openai / github / etc.), label, and paste the value.
+3. Rotate inline per row; revoke removes the row immediately.
+
+Every displayed value is masked to `••••••••<last-4>`. The plaintext is never shown after creation — if you lose it, rotate.
+
+## How the dashboard uses stored keys
+
+When you hit "Fix this" on a failing span, the fix dialog's **Provider + key picker** fetches `/v1/projects/:id/keys`, filters by `kind` + `provider`, and renders a `<select>` of your stored keys. You pick one by ID — the browser never sees the plaintext; the collector resolves the ID → plaintext internally at the moment of the outbound LLM call, and forgets it immediately.
+
+## Security invariants
+
+Enforced at every write path and audited via [`packages/keys/LEAK-AUDIT.md`](../packages/keys/LEAK-AUDIT.md):
+
+1. **Plaintext is NEVER stored.** Every write goes through `seal()` before `INSERT`.
+2. **Plaintext is NEVER logged.** Not in `console.*`, not in errors, not in HTTP response bodies, not in Pathlight traces.
+3. **Endpoints NEVER return plaintext.** `POST` returns masked metadata; `GET` lists are metadata-only; `PUT` (rotate) returns the new masked metadata. The only path that returns plaintext is the internal `resolveSecret`, and it's per-project scoped.
+4. **Fail-stop on missing/malformed `PATHLIGHT_SEAL_KEY`.** No default, no fallback, no insecure generation.
+5. **Constant-time opaque failure.** Corrupt ciphertext throws a generic `DecryptionError` with no detail.
+6. **Cross-project access returns `null`.** Same response shape as not-found so callers cannot probe which IDs exist under other projects.
+7. **Kind filtering on the resolver.** `resolveLlmKey` only returns keys with `kind: "llm"`; `resolveGitToken` only returns `kind: "git"`. Cross-kind access gets `null` — no mis-typed secrets flowing into the wrong API.
+
+## Cryptography
+
+- Primitive: libsodium `crypto_secretbox_easy` (authenticated encryption).
+- Nonce: fresh random per value (`crypto_secretbox_NONCEBYTES`, stored packed with ciphertext).
+- Key: 32 bytes from `PATHLIGHT_SEAL_KEY`, validated at load time.
+- No master-key rotation automation in v1 — documented as an ops follow-up.
+
+## Endpoints
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/v1/projects/:id/keys` | GET | List keys (masked metadata only) |
+| `/v1/projects/:id/keys` | POST | Create a key. Body: `{ kind, provider, label, value }`. Returns masked metadata. |
+| `/v1/projects/:id/keys/:keyId` | PUT | Rotate atomically (create new + delete old in a transaction). Returns new masked metadata. |
+| `/v1/projects/:id/keys/:keyId` | DELETE | Revoke immediately. |
+
+Responses never include the plaintext, even after `POST`. If you need the raw value, you need to know it at creation time — it doesn't leave the server round-trip for later retrieval.
+
+## Backups
+
+Database backups (`pathlight.db`) contain the sealed ciphertext. Safe as long as `PATHLIGHT_SEAL_KEY` lives separately (not in the same backup bundle). Document this in your deploy runbook.
+
+## Known limitations (v1)
+
+- **No automated master-key rotation.** Changing `PATHLIGHT_SEAL_KEY` invalidates all stored ciphertext. Rotation requires dump + re-seal + reload.
+- **Per-project scoping only.** When auth lands, revisit whether `projectId` alone is the right ACL — user/session scoping will probably layer on top.
+- **Manual project ID entry in the UI.** Current behavior; comes from session context once auth is added.
+
+## Package
+
+[`packages/keys`](../packages/keys) in this repo; not published to npm (internal package).

--- a/docs/fix.md
+++ b/docs/fix.md
@@ -1,0 +1,159 @@
+# Code-fixing agent
+
+Pathlight reads a failing trace and proposes a diff that fixes the root cause — BYOK (your own LLM key, your own LLM traffic) and git-provenance-aware (bisect across commits to pin regressions to a specific SHA).
+
+Three surfaces over one core:
+
+- **Library** — `@pathlight/fix` exports a pure `fix()` function.
+- **CLI** — `pathlight fix <trace-id>` for headless / CI use.
+- **Dashboard** — "Fix this" button on every failed span, streaming diff preview, one-click apply.
+
+## Quick start — CLI
+
+```bash
+# Path mode (local source tree)
+export PATHLIGHT_LLM_API_KEY=sk-ant-...
+pathlight fix trc_xxx --source-dir . --apply
+
+# Git mode (remote clone, read-only)
+export PATHLIGHT_LLM_API_KEY=sk-...
+export PATHLIGHT_GIT_TOKEN=ghp_...
+pathlight fix trc_xxx --git-url https://github.com/acme/repo.git --provider openai
+
+# Bisect — find the regression commit across a SHA range
+pathlight fix trc_xxx \
+  --bisect --from <good-sha> --to <bad-sha> \
+  --git-url https://github.com/acme/repo.git
+```
+
+Progress prints to stderr (`# fetching trace`, `# calling anthropic claude-opus-4-7`, `# bisect depth 2 at abc1234`); the diff writes to stdout so you can pipe:
+
+```bash
+pathlight fix trc_xxx > /tmp/fix.patch
+git checkout -b fix/trc_xxx
+git apply /tmp/fix.patch
+```
+
+## Quick start — Dashboard
+
+1. Open a failing trace at http://localhost:3100.
+2. Click any failed span. The inspector shows a **Fix this** button.
+3. Dialog opens with the form:
+   - Source mode: local path or git URL + token
+   - Provider: Anthropic or OpenAI (with an empty-state link to `/settings/keys` if you have none)
+   - Mode: span / trace / bisect
+4. Submit. SSE progress streams live.
+5. On result: diff preview renders with per-file expand/collapse, **Apply to working tree** (path mode), **Download .patch**, or **Copy**.
+
+If the run used bisect, a banner above the diff shows the regression SHA and links to `/commits`.
+
+## Quick start — Library
+
+```typescript
+import { fix } from "@pathlight/fix";
+
+const result = await fix({
+  traceId: "trc_xxx",
+  collectorUrl: "http://localhost:4100",
+  source: { kind: "path", dir: "/abs/path/to/repo" },
+  llm: {
+    provider: "anthropic",
+    apiKey: process.env.ANTHROPIC_API_KEY!,
+    // model: "claude-opus-4-7",  // defaults per provider
+  },
+  mode: { kind: "span" },          // "span" | "trace" | "bisect"
+  onProgress: (evt) => console.error(evt),
+});
+
+console.log(result.diff);          // unified diff, git-apply-ready
+console.log(result.explanation);
+console.log(result.filesChanged);
+if (result.regressionSha) console.log("regression at", result.regressionSha);
+```
+
+## What it does
+
+| Mode | Behavior |
+| --- | --- |
+| `span` | Fix the failing span(s) on the given trace. Default. |
+| `trace` | Analyze the whole trace. Fix any failure found. |
+| `bisect` | Walk a commit range, identify the regression commit via binary search, propose a fix against that SHA. Requires a git source. |
+
+## Source access
+
+- **Path mode** — engine reads files directly from `dir`. Reads are scoped: no `..` escapes allowed.
+- **Git mode** — engine shallow-clones (`depth=1` by default; deepens automatically during bisect) into a temp dir, checks out `ref`, cleans up on exit. Read-only tokens only in v1 — no branch push, no PR creation.
+
+## How file selection works
+
+Every span the Pathlight SDK creates auto-attaches `metadata._source = { file, line, column, func }`. The fix engine reads those `_source.file` values off the failing spans, relativizes them against the source root, and sends only those files to the LLM. No directory crawl, no "please specify files" UX, no extra LLM round-trip.
+
+For traces with no `_source` metadata (e.g. OTLP ingests), the prompt falls back to asking the LLM for file paths in its explanation. The engine returns an empty diff + a description of what's needed rather than guessing blindly.
+
+## Bisect details
+
+1. Validates `to` reproduces the failure and `from` does not — two endpoint probes.
+2. Binary-searches the `from..to` commit range — O(log₂ N) probe calls for N commits.
+3. Returns `{ regressionSha, parentSha, diff, explanation, ... }` where the diff is proposed against `regressionSha`.
+
+Each probe does a fresh checkout in the tempdir and either re-runs the span-mode fix engine there or calls your custom `bisectProbe`. Shallow clones are deepened automatically if a probe SHA isn't in the current history.
+
+Supply a custom probe (e.g. backed by `pathlight-eval` assertions):
+
+```typescript
+import { fix } from "@pathlight/fix";
+
+await fix({
+  // ...
+  mode: { kind: "bisect", from: "abc123", to: "def456" },
+  bisectProbe: async (sha) => {
+    // your eval / test runner / heuristic
+    const failed = await runEval(sha);
+    return failed ? "bad" : "good";
+  },
+});
+```
+
+## BYOK invariants
+
+These are enforced at every boundary — library, CLI, web API:
+
+1. **Keys are never logged.** Not in `console.*`, not in errors, not in traces. The CLI scrubs any known token from its error path before printing.
+2. **`FixError.cause` is non-enumerable** so default `JSON.stringify`/`console.error`/`util.inspect` cannot walk into SDK error payloads that might echo request headers.
+3. **Every invocation emits a meta-trace** (`fix.engine`) to the Pathlight collector. The meta-trace carries mode, source kind, provider, model, token counts, and files-changed — but never the diff body, the explanation text, the API key, or the git token.
+4. **Git tokens are read-only in v1.** No push, no PR creation. Extending to write requires auth work which is deferred.
+
+See [packages/keys/LEAK-AUDIT.md](../packages/keys/LEAK-AUDIT.md) for the reusable audit checklist (applies to the BYOK key store; the engine follows the same rules).
+
+## Providers
+
+| Provider | Default model | Auth env |
+| --- | --- | --- |
+| Anthropic | `claude-opus-4-7` | `PATHLIGHT_LLM_API_KEY` (sk-ant-…) |
+| OpenAI | `gpt-5.4` | `PATHLIGHT_LLM_API_KEY` (sk-…) |
+
+Override with `--model <id>` or `llm.model`.
+
+## Web API
+
+The collector exposes the engine over SSE so the dashboard (and any other client) can drive it remotely:
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/v1/fix` | POST | Run the fix engine; response is `text/event-stream` with `progress`, `chunk`, `result`, `error`, `done` events |
+| `/v1/fix-apply` | POST | Write a diff to a local working tree via `git apply`. Body: `{ sourceDir, diff }`. Runs `git apply --check` first. Self-hosted trust model — gate behind an operator flag for any hosted deployment. |
+
+The `/v1/fix` route resolves `keyId`/`tokenId` references (from [BYOK key storage](byok-keys.md)) internally and never accepts raw plaintext secrets from the wire.
+
+## Troubleshooting
+
+- **"Fix this" button is missing.** It only renders on spans with `status: failed`, `span.error` set, or output matching the suspicious-output heuristic (fail/failed/error/timeout/invalid/…). If your failure doesn't match, use the CLI.
+- **Engine returned an empty diff.** Read the explanation — the model is telling you what context it needs. Re-run with a better source tree (e.g. the specific subdirectory) or pass a more targeted `mode: "trace"` if the failing span doesn't have a `_source.file` attached.
+- **Git clone fails with "authentication failed".** Use a read-only PAT with `contents:read` scope. The token is never stored — it lives only for the duration of one `fix()` invocation.
+- **`git apply` fails in dashboard mode.** The pre-check caught a conflict. Sync your source tree, re-run, or apply the downloaded `.patch` file manually.
+
+## Packages
+
+- [`@pathlight/fix`](../packages/fix/README.md) — core library
+- [`@pathlight/cli`](../packages/cli/README.md) — `pathlight fix` subcommand
+- Dashboard components at `apps/web/src/components/Fix/`

--- a/docs/openclaw-plugin.md
+++ b/docs/openclaw-plugin.md
@@ -1,0 +1,66 @@
+# OpenClaw plugin
+
+`@pathlight/openclaw` is a first-party [OpenClaw](https://openclaw.ai) plugin that captures agent runs, LLM calls, tool execution, and sub-agent delegation as Pathlight traces with zero code changes.
+
+Differentiator vs competing observability plugins: every trace carries `git_commit` / `git_branch` / `git_dirty` automatically, so the `/commits` regression view and the fix-engine bisect (see [docs/fix.md](fix.md)) see your OpenClaw runs the same way they see SDK-instrumented code.
+
+## Install
+
+```bash
+openclaw plugins install @pathlight/openclaw
+```
+
+## Configure
+
+Via env vars (the primary path):
+
+```bash
+export PATHLIGHT_BASE_URL=http://localhost:4100
+export PATHLIGHT_API_KEY=pk_live_...        # optional; not required for local collectors
+export PATHLIGHT_PROJECT_ID=proj_xyz        # optional
+```
+
+Or via OpenClaw's plugin-config file (precedence: plugin config > env > defaults):
+
+```json
+{
+  "pathlight": {
+    "baseUrl": "https://collector.example.com",
+    "apiKey": "pk_live_...",
+    "projectId": "proj_xyz"
+  }
+}
+```
+
+Defaults: `baseUrl=http://localhost:4100`, no API key, no project ID.
+
+## What gets traced
+
+| OpenClaw event | Pathlight span |
+| --- | --- |
+| `before_agent_start` → `agent_end` | Root trace (with `git_commit` / `git_branch` / `git_dirty`) |
+| `llm_input` → `llm_output` | `llm` span with model, provider, input/output, token usage |
+| `before_tool_call` → `after_tool_call` | `tool` span with name, args, result |
+| `subagent_spawning` → `subagent_ended` | `agent` span in the parent trace (the child run gets its own trace) |
+
+Memory hooks are intentionally out of scope in v1 — the hook surface is still stabilizing upstream.
+
+## Sub-agent nesting
+
+OpenClaw sub-agents are separate runs with their own `runId`. The plugin emits an `agent`-type **marker span** in the parent trace (carrying `childSessionKey` + `parentRunId` metadata) and lets the child's own `before_agent_start` hook open its own top-level Pathlight trace. Cross-trace linking via metadata is a planned UX pass.
+
+## Graceful degradation
+
+If the Pathlight collector is unreachable the plugin logs one warning and continues best-effort. A downed collector will never crash an OpenClaw run.
+
+Per-hook errors are caught in a shared `safeOn` wrapper, so a single throwing hook can never take down the plugin.
+
+## Security
+
+- Plugin code runs in-process with the OpenClaw Gateway (trusted native plugin).
+- The Pathlight API key (when set) is sent only to the configured `baseUrl`, never logged.
+- No user prompt content leaves your infra unless your collector is off-box.
+
+## Package
+
+[`packages/openclaw-plugin`](../packages/openclaw-plugin/README.md) in this repo; published as `@pathlight/openclaw` on npm.


### PR DESCRIPTION
## Summary

Post-ship documentation sync for the six feature PRs that landed in P5 (#43, #50, #51, #52, #53, #54). Adds three per-feature deep-dives, refreshes README + CHANGELOG + CLAUDE.md to describe what's on master, and updates the TopNav to surface the new Settings route.

## What's in here

- **New docs**
  - `docs/fix.md` — the code-fixing agent (library + CLI + dashboard)
  - `docs/byok-keys.md` — encrypted key storage + management UI
  - `docs/openclaw-plugin.md` — OpenClaw plugin install and hooks
- **README.md** — feature tour, workflow playbooks, architecture tree, API reference, env vars, commands, self-hosted philosophy all updated for master
- **CHANGELOG.md** — three new \`Unreleased — Added\` sections for #42, #44/#45–#49, and #48; plus a \`Changed\` block for TopNav + BYOK opt-in
- **CLAUDE.md** — new packages (\`fix\`, \`keys\`, \`openclaw-plugin\`) in the architecture, new commands section, UI conventions for the Fix dialog, BYOK security invariants
- **TopNav** — adds a Settings link and bumps the version badge to v0.3.0

## Testing

- \`npx turbo build\` — 9/9 packages build clean

## Notes

No new features. No code changes beyond the TopNav link + version bump. Pure documentation + site discoverability sync.

---
Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)