### PR TITLE
fix(#59): stop FixStream from aborting on parent re-render

### DIFF
--- a/apps/web/src/app/traces/[id]/page.tsx
+++ b/apps/web/src/app/traces/[id]/page.tsx
@@ -10,6 +10,7 @@ import { FixDialog, type FixContext } from "../../../components/Fix/FixDialog";
 
 interface Trace {
   id: string;
+  projectId: string | null;
   name: string;
   status: string;
   input: string | null;

--- a/apps/web/src/components/Fix/FixStream.tsx
+++ b/apps/web/src/components/Fix/FixStream.tsx
@@ -32,8 +32,25 @@ export function FixStream({ projectId, traceId, form, onResult, onFail }: FixStr
   const [closed, setClosed] = useState(false);
   const idRef = useRef(0);
 
+  // Keep callbacks in refs so they don't appear in the effect's deps. The
+  // parent (FixDialog) passes fresh inline closures every render; without
+  // this indirection any unrelated re-render of the dialog would tear
+  // down + abort the in-flight SSE stream. In React StrictMode (Next.js
+  // dev) the abort flips phase → error and unmounts FixStream before the
+  // second mount can complete, so submission appeared to fail instantly.
+  const onResultRef = useRef(onResult);
+  const onFailRef = useRef(onFail);
+  useEffect(() => {
+    onResultRef.current = onResult;
+    onFailRef.current = onFail;
+  }, [onResult, onFail]);
+
   useEffect(() => {
     const controller = new AbortController();
+    // Distinguish caller-driven aborts (effect cleanup, e.g. on unmount)
+    // from real network/SSE failures so cleanup never reaches onFail.
+    let cleanedUp = false;
+
     const pushProgress = (text: string): void => {
       idRef.current += 1;
       const entry = { id: idRef.current, text };
@@ -65,12 +82,12 @@ export function FixStream({ projectId, traceId, form, onResult, onFail }: FixStr
           }
           case "result": {
             const parsed = safeJson(event.data) as FixResultPayload;
-            onResult(parsed);
+            onResultRef.current(parsed);
             return;
           }
           case "error": {
             const parsed = safeJson(event.data) as { message?: string };
-            onFail(parsed?.message ?? "Fix engine failed");
+            onFailRef.current(parsed?.message ?? "Fix engine failed");
             return;
           }
           case "done": {
@@ -80,13 +97,17 @@ export function FixStream({ projectId, traceId, form, onResult, onFail }: FixStr
         }
       },
       onError: (err) => {
-        onFail(err instanceof Error ? err.message : "Connection error");
+        if (cleanedUp || controller.signal.aborted) return;
+        onFailRef.current(err instanceof Error ? err.message : "Connection error");
       },
       onClose: () => setClosed(true),
     });
 
-    return () => controller.abort();
-  }, [projectId, traceId, form, onResult, onFail]);
+    return () => {
+      cleanedUp = true;
+      controller.abort();
+    };
+  }, [projectId, traceId, form]);
 
   return (
     <div className="bg-zinc-950 border border-zinc-800 rounded-lg">


### PR DESCRIPTION
Closes #59.

## Summary

- Move `onResult` / `onFail` behind refs in `FixStream` so they don't trigger the SSE effect to re-run when the parent (`FixDialog`) passes fresh inline closures.
- Ignore `AbortError` raised by the cleanup function so unmount-driven aborts no longer surface as `onFail("signal is aborted without reason")`.
- Add `projectId` to the local `Trace` type in `apps/web/src/app/traces/[id]/page.tsx` so the b5bd0c1 fix typechecks (was previously read via a `parseJson(metadata)` cast that silently accepted any shape).

## Repro before fix

1. `npm run dev -w apps/web` (Next 15 / StrictMode on by default).
2. Open a failed trace, click **Fix this**.
3. Fill source dir, select a BYOK key, click **Propose fix**.
4. Observe immediate `signal is aborted without reason` and dialog state → error.

## After fix

Same flow under `next dev`: the stream completes, `EXPLANATION` and unified diff render. Verified against `traces/duGwFI_t1sS9WF1tlmV3V` with the seeded `examples/quote-agent` source.

## Test plan

- [ ] `next dev` with StrictMode on, fix flow submits and renders a diff
- [ ] Production build (no StrictMode) — same flow still works (regression check)
- [ ] Closing the dialog mid-stream does not raise an error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
